### PR TITLE
fix is_epyc() in server.py; read server info with sshconf and glances

### DIFF
--- a/perf/server.py
+++ b/perf/server.py
@@ -7,18 +7,38 @@ import time
 import getpass
 import ast
 import psutil
+import requests
+from sshconf import read_ssh_config
+import os.path as osp
+import random
+import numpy as np
+
 
 class Server(object):
-  def __init__(self, ip):
-    # if not is_epyc():
-    #   print(f"Only epyc is supported. {ip} is not epyc")
-    #   sys.exit()
-    self.ip = ip
-    self.username = getpass.getuser()
+  glance_port = 61208
+  def __init__(self, node_name):
+    ssh_conf_file = osp.expanduser('~/.ssh/config')
+    openssh_config_exist = osp.exists(ssh_conf_file)
+    if openssh_config_exist:
+      ssh_conf = read_ssh_config(ssh_conf_file)
+      host_conf = ssh_conf.host(node_name)
+      found_node_name_in_ssh = 'hostname' in host_conf
+    else:
+      found_node_name_in_ssh = False
+
+    if openssh_config_exist and found_node_name_in_ssh:
+      print(host_conf)
+      self.ip = host_conf['hostname']
+      self.username = getpass.getuser()
+      self.remote_cmd = ["ssh", node_name]
+    else:
+      self.ip = node_name
+      self.username = getpass.getuser()
+      self.remote_cmd = ["ssh", f"{self.username}@{self.ip}"]
+
     self.failed_tests = []
     self.success_tests = []
     self.pending_proc = []
-    self.remote_cmd = ["ssh", f"{self.username}@{self.ip}"]
 
   def pending_tests(self):
     self.check_running()
@@ -27,12 +47,12 @@ class Server(object):
       tests.append(proc[0])
     return tests
 
-  def numactl(self, cmd, mem, start, end):
-    if not self.is_epyc():
+  def numactl(self, cmd, mem, start, end, num_cores):
+    if not self.is_epyc(num_cores):
       return cmd
     return ["numactl", "-m", f"{str(mem)}", "-C", f"{start}-{end}"] + cmd
 
-  def remote_get_free_cores(self, threads):
+  def remote_get_free_cores_ssh(self, threads):
     pwd = os.path.dirname(os.path.abspath(__file__))
     cmd = ["python3", f"{pwd}/get_free_core.py", f"{threads}"]
     ssh_cmd_str = " ".join(self.remote_cmd + cmd)
@@ -40,9 +60,61 @@ class Server(object):
     proc = os.popen(ssh_cmd_str)
     result = proc.read().strip()
     result = ast.literal_eval(result)
+    # (free, mem, start, end, server_cores)
     return result
 
-  def assign(self, test_name, cmd, threads, xs_path, stdout_file, stderr_file):
+  def remote_get_free_cores_glance(self, threads):
+    # curl http://localhost:61208/api/3/core
+    # return: {"log": 4, "phys": 2}
+    print("url:", f"http://{self.ip}:{Server.glance_port}/api/3/core")
+    core_info = requests.get(f"http://{self.ip}:{Server.glance_port}/api/3/core").json()
+    num_phys_cores = core_info['phys']
+    num_log_cores = core_info['log']
+    has_smt = num_phys_cores*2 == num_log_cores
+
+    num_windows = num_phys_cores // threads
+    rand_windows = np.random.permutation(num_windows)  # use random windows to avoid unexpected waiting on a free window
+    window_usage_thres = 20 * threads
+
+    per_core_info = requests.get(f"http://{self.ip}:{Server.glance_port}/api/3/percpu").json()
+    # curl http://localhost:61208/api/3/percpu
+    # return:
+    # [{"cpu_number": 0,
+    #   ....
+    #   "idle": 26.2,
+    #   ....
+    #   "system": 4.4,
+    #   "total": 73.8,
+    #   "user": 68.0},
+    # {"cpu_number": 1,
+    #   ....}
+    # ]
+
+    for w in rand_windows:
+      window_uasge = 0
+      for i in range(threads):
+        core_id = w * threads + i
+        window_uasge += per_core_info[core_id]['total']
+        if has_smt:
+          smt_sibling = core_id + num_phys_cores
+          window_uasge += per_core_info[smt_sibling]['total']
+      start = w * threads
+      end = w * threads + threads - 1
+      if window_uasge < window_usage_thres:
+        # always assume numa with 2 cpus
+        numa_node = int(start >= (num_phys_cores // 2))
+        return (True, numa_node, start, end, num_phys_cores)
+    return (False, 0, 0, 0, num_phys_cores)
+
+  def remote_get_free_cores(self, threads):
+    try:
+      info = self.remote_get_free_cores_glance(threads)
+    except Exception as e:
+      print("Failed to get free cores from glance, fallback to ssh:", e)
+      info = self.remote_get_free_cores_ssh(threads)
+    return info
+
+  def assign(self, test_name, cmd, threads, xs_path, stdout_file, stderr_file, dry_run=False):
     self.check_running()
     (free, mem, start, end, server_cores) = self.remote_get_free_cores(threads)
     # print(free, mem, start, end, server_cores)
@@ -52,14 +124,17 @@ class Server(object):
       pending_cores = running[2]
       if (start, end) == pending_cores:
         return False
-    run_cmd = self.numactl(cmd, mem, start, end)
+    if dry_run:
+      cmd = ["hostname;", "sleep", "60"]
+    run_cmd = self.numactl(cmd, mem, start, end, server_cores)
     run_cmd = self.remote_cmd + [f"NOOP_HOME={xs_path}"] + run_cmd
     os.system("date")
     print(f"{' '.join(run_cmd)}")
 
     with open(stdout_file, "w") as stdout, open(stderr_file, "w") as stderr:
       proc = subprocess.Popen(run_cmd, stdout=stdout, stderr=stderr, preexec_fn=os.setsid)
-      time.sleep(1)
+      if not dry_run:
+        time.sleep(1)
     self.pending_proc.append((test_name, proc, (start, end)))
     if (len(self.pending_proc) > (server_cores // threads)):
       print(f"Server {self.ip} has more than {len(self.pending_proc)} proc. Is it OK?")
@@ -91,6 +166,5 @@ class Server(object):
     pwd = os.path.dirname(os.path.abspath(__file__))
     os.popen(" ".join(self.remote_cmd) + f" python3 {pwd}/stop_emu.py")
 
-  def is_epyc(self):
-    num_core = psutil.cpu_count(logical=False)
-    return num_core > 16
+  def is_epyc(self, num_cores):
+    return num_cores > 16

--- a/perf/xs_autorun_multiServer.py
+++ b/perf/xs_autorun_multiServer.py
@@ -121,7 +121,7 @@ def xs_run(server_list, workloads, xs_path, warmup, max_instr, threads):
       assigned = False
       while not assigned:
         for s in servers:
-          if s.assign(f"{workload}", run_cmd, threads, xs_path, workload.get_out_path(), workload.get_err_path()):
+          if s.assign(f"{workload}", run_cmd, threads, xs_path, workload.get_out_path(), workload.get_err_path(), dry_run):
             assigned = True
             count = count + 1
             break
@@ -338,6 +338,7 @@ if __name__ == "__main__":
   parser.add_argument('--dir', default=None, type=str, help='SPECTasks dir')
   parser.add_argument('--jobs', '-j', default=1, type=int, help="processing files in 'j' threads")
   parser.add_argument('--resume', action='store_true', default=False, help="continue to exe, ignore the aborted and success tests")
+  parser.add_argument('--dry-run', action='store_true', default=False, help="does not run real simulation")
 
   args = parser.parse_args()
 
@@ -410,4 +411,4 @@ if __name__ == "__main__":
     print("All:  ", len(gcpt))
     print("First:", gcpt[0])
     print("Last: ", gcpt[-1])
-    xs_run(args.server_list, gcpt, args.xs, args.warmup, args.max_instr, args.threads)
+    xs_run(args.server_list, gcpt, args.xs, args.warmup, args.max_instr, args.threads, args.dry_run)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ PyYAML==6.0
 tqdm==4.64.1
 yagmail==0.15.293
 PyGithub==1.57
+numpy
+sshconf


### PR DESCRIPTION
- is_epyc should use remote server info instead of local
- allow to parse server list from openssh config
- obtain server core count and load info from glance servers (if exists), which avoids remote command execution trick when searching free ccx windows.