### PR TITLE
glance: update glance api v3 --> v4; fix ssh; and fix typo

### DIFF
--- a/perf/cpuutil.py
+++ b/perf/cpuutil.py
@@ -13,7 +13,6 @@ def get_free_cores(n):
     free = sum(window_usage) < 30 * n and True not in map(lambda x: x > 80, window_usage if is_epyc() else core_usage)
     if free:
       # return (Success?, memory node, start_core, end_core)
-      print(f'num_core: {num_core}, num_window: {num_window}, start: {i * n}, end: {i * n + n - 1}')
       return (True, ((i * n) % num_core)// (num_core//2), i * n, i * n + n - 1, num_core)
   return (False, 0, 0, 0, num_core)
   # print(f"No free {n} cores found. CPU usage: {core_usage}\n")


### PR DESCRIPTION
- When glance fails, fall back on ssh. During calling get_free_cores in cpuutils.py, we should not print anything. Because remote_get_free_cores_ssh depends on stdout to get result from ssh call.