### PR TITLE
cpuutil: use status to judge unset cores

### DIFF
--- a/perf/server.py
+++ b/perf/server.py
@@ -60,7 +60,7 @@ class Server(object):
     proc = os.popen(ssh_cmd_str)
     result = proc.read().strip()
     if len(result)==0:
-      result="(False, 0, 0, 0)"
+      return "(False, 0, 0, 0)"
     result = ast.literal_eval(result)
     # (free, mem, start, end, server_cores)
     return result


### PR DESCRIPTION
1. use the status of process to judge whether the cpus in cpu affinity is bound. It is more effective than using the usage of cpu.