### PR TITLE
fix(fpga_diff): remove legacy `gateway_interface` header

### DIFF
--- a/fpga_diff/src/rtl/common/core_def_xdma.sv
+++ b/fpga_diff/src/rtl/common/core_def_xdma.sv
@@ -1,10 +1,6 @@
 `include "sys_define.vh"
 `include "DifftestMacros.v"
 
-`ifdef CPU_XIANGSHAN
-`include "gateway_interface.svh"
-`endif
-
 module core_def (
       input                                      ddr_clk_p,
       input                                      ddr_clk_n, 


### PR DESCRIPTION
When using the AXI bus, generate the difftest in a single step, and there is no longer a need for the interface. The interface.svh file needs to be referenced when using the non-tilelink environment.