### PR TITLE
fpga_diff: add support for Vivado 2025

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -1,4 +1,5 @@
 PRJ ?=
+ENV_SCRIPTS_HOME ?= $(CURDIR)
 
 CORE_DIR ?= ""
 FPGA_BIT_HOME ?=
@@ -11,6 +12,12 @@ CPU ?= ""
 
 .PHONY: bitstream vivado
 
+# Get Vivado version
+VIVADO_VERSION := $(shell vivado -version 2>/dev/null | head -1 | grep -o '[0-9]\{4\}\.[0-9]' || echo "unknown")
+
+check_vivado_version:
+	@vivado -version 2>/dev/null | head -1 | grep -o '[0-9]\{4\}\.[0-9]' || echo "unknown"
+
 synth:
 	vivado -mode batch -source ./tools/gen_synth.tcl -tclargs $(PRJ)
 
@@ -22,8 +29,11 @@ update_core_flist:
 	find "$(CORE_DIR)" -type f \( -name "*.v" -o -name "*.sv" -o -name "*.svh" \) -printf '%p\n' | \
 	awk -f ./core_flist.awk > ./src/tcl/cpu_files.tcl
 
-vivado:
-	vivado -mode batch -source src/tcl/common/xs_uart.tcl -tclargs --cpu $(CPU) --project_name fpga_$(CPU)
+vivado: check_vivado_version
+	vivado -mode batch -source src/tcl/common/xs_uart.tcl -tclargs --cpu $(CPU) --project_name fpga_$(CPU) --vivado_version $(VIVADO_VERSION)
+
+check_version:
+	vivado -mode batch -source src/tcl/common/check_version.tcl -tclargs --vivado_version $(VIVADO_VERSION) --cpu $(CPU) --project_name fpga_$(CPU)
 
 write_bitstream:
 	sh tools/pcie-remove.sh
@@ -45,3 +55,7 @@ get_impl_log:
 
 get_synth_log:
 	cat fpga_$(CPU)/fpga_$(CPU).runs/synth_1/runme.log
+
+all:
+	$(MAKE) update_core_flist CORE_DIR=$(CORE_DIR)
+	$(MAKE) vivado CPU=$(CPU)

--- a/fpga_diff/src/rtl/common/core_def_xdma.sv
+++ b/fpga_diff/src/rtl/common/core_def_xdma.sv
@@ -1060,6 +1060,8 @@ assign i2c2_prdata = 0;
   wire        XDMA_AXI_LITE_rvalid;
   wire        XDMA_AXI_LITE_rready;
 
+  wire difftest_to_host_axis_ready_io;
+  wire difftest_to_host_axis_valid_io;
   wire difftest_to_host_axis_ready;
   wire difftest_to_host_axis_valid;
   wire [511:0] difftest_to_host_axis_bits_data;
@@ -1075,14 +1077,17 @@ assign i2c2_prdata = 0;
   assign sys_rstn_io = sys_rstn & ~host_io_reset;
   assign cpu_rstn_io = cpu_rstn & ~host_io_reset;
 
+  assign difftest_to_host_axis_ready =  difftest_to_host_axis_ready_io & pcie_ep_lnk_up;
+  assign difftest_to_host_axis_valid_io = difftest_to_host_axis_valid & pcie_ep_lnk_up;
+
   xdma_ep xdma_ep_i(
     .cpu_clk(sys_clk_i),
     .cpu_rstn(sys_rstn),
     .S00_AXIS_0_tdata(difftest_to_host_axis_bits_data),
     .S00_AXIS_0_tkeep(64'hffffffff_ffffffff),
     .S00_AXIS_0_tlast(difftest_to_host_axis_bits_last),
-    .S00_AXIS_0_tready(difftest_to_host_axis_ready),
-    .S00_AXIS_0_tvalid(difftest_to_host_axis_valid),
+    .S00_AXIS_0_tready(difftest_to_host_axis_ready_io),
+    .S00_AXIS_0_tvalid(difftest_to_host_axis_valid_io),
     
     .XDMA_AXI_LITE_awaddr (XDMA_AXI_LITE_awaddr),
     .XDMA_AXI_LITE_awprot (3'b000),

--- a/fpga_diff/src/tcl/common/AXI_bridge.tcl
+++ b/fpga_diff/src/tcl/common/AXI_bridge.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2020.2
+set scripts_vivado_version $::vivado_version
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {

--- a/fpga_diff/src/tcl/common/blk_mem_gen_0.tcl
+++ b/fpga_diff/src/tcl/common/blk_mem_gen_0.tcl
@@ -2,7 +2,7 @@
 # CHECK VIVADO VERSION
 ##################################################################
 
-set scripts_vivado_version 2020.2
+set scripts_vivado_version $::vivado_version
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {

--- a/fpga_diff/src/tcl/common/data_bridge.tcl
+++ b/fpga_diff/src/tcl/common/data_bridge.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2020.2
+set scripts_vivado_version $::vivado_version
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {

--- a/fpga_diff/src/tcl/common/jtag_ddr_subsys.tcl
+++ b/fpga_diff/src/tcl/common/jtag_ddr_subsys.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2020.2
+set scripts_vivado_version $::vivado_version
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {

--- a/fpga_diff/src/tcl/common/vio_0.tcl
+++ b/fpga_diff/src/tcl/common/vio_0.tcl
@@ -2,7 +2,7 @@
 # CHECK VIVADO VERSION
 ##################################################################
 
-set scripts_vivado_version 2020.2
+set scripts_vivado_version $::vivado_version
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {

--- a/fpga_diff/src/tcl/common/xdma_ep.tcl
+++ b/fpga_diff/src/tcl/common/xdma_ep.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2020.2
+set scripts_vivado_version $::vivado_version
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -122,11 +122,23 @@ set bCheckIPsPassed 1
 ##################################################################
 set bCheckIPs 1
 if { $bCheckIPs == 1 } {
-   set list_check_ips "\ 
-xilinx.com:ip:axis_clock_converter:1.1\
-xilinx.com:ip:util_ds_buf:2.1\
-xilinx.com:ip:xdma:4.1\
-"
+  common::send_gid_msg -ssname BD::TCL -id 2058 -severity "INFO" "Current scripts_vivado_version value: '$::vivado_version'"
+  
+  if {[string match "*2025.1*" $::vivado_version]} {
+    set list_check_ips "\ 
+    xilinx.com:ip:axis_clock_converter:1.1\
+    xilinx.com:ip:axis_dwidth_converter:1.1\
+    xilinx.com:ip:util_ds_buf:2.2\
+    xilinx.com:ip:xdma:4.2\
+    "
+  } else {
+    set list_check_ips "\ 
+    xilinx.com:ip:axis_clock_converter:1.1\
+    xilinx.com:ip:axis_dwidth_converter:1.1\
+    xilinx.com:ip:util_ds_buf:2.1\
+    xilinx.com:ip:xdma:4.1\
+    "
+  }
 
    set list_ips_missing ""
    common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
@@ -243,55 +255,103 @@ proc create_root_design { parentCell } {
   set axis_clock_converter_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_clock_converter:1.1 axis_clock_converter_0 ]
 
   # Create instance: util_ds_buf_0, and set properties
-  set util_ds_buf_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.1 util_ds_buf_0 ]
+  if {[string match "*2025.1*" $::vivado_version]} {
+     set util_ds_buf_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.2 util_ds_buf_0 ]
+  } else {
+     set util_ds_buf_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.1 util_ds_buf_0 ]
+  }
   set_property -dict [ list \
    CONFIG.C_BUF_TYPE {IBUFDSGTE} \
  ] $util_ds_buf_0
 
   # Create instance: xdma_0, and set properties
-  set xdma_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xdma:4.1 xdma_0 ]
-  set_property -dict [ list \
-   CONFIG.PF0_DEVICE_ID_mqdma {9048} \
-   CONFIG.PF2_DEVICE_ID_mqdma {9048} \
-   CONFIG.PF3_DEVICE_ID_mqdma {9048} \
-   CONFIG.axi_data_width {512_bit} \
-   CONFIG.axilite_master_en {true} \
-   CONFIG.axisten_freq {250} \
-   CONFIG.cfg_mgmt_if {false} \
-   CONFIG.coreclk_freq {500} \
-   CONFIG.en_gt_selection {true} \
-   CONFIG.mode_selection {Advanced} \
-   CONFIG.pcie_blk_locn {PCIE4C_X0Y4} \
-   CONFIG.pf0_device_id {9048} \
-   CONFIG.pf0_msix_cap_pba_bir {BAR_1} \
-   CONFIG.pf0_msix_cap_table_bir {BAR_1} \
-   CONFIG.pl_link_cap_max_link_speed {16.0_GT/s} \
-   CONFIG.pl_link_cap_max_link_width {X8} \
-   CONFIG.plltype {QPLL0} \
-   CONFIG.select_quad {GTY_Quad_231} \
-   CONFIG.xdma_axi_intf_mm {AXI_Stream} \
- ] $xdma_0
+  if {[string match "*2025.1*" $::vivado_version]} {
+     set xdma_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xdma:4.2 xdma_0 ]
+      set_property -dict [list \
+        CONFIG.PF0_DEVICE_ID_mqdma {9048} \
+        CONFIG.PF0_SRIOV_VF_DEVICE_ID {A048} \
+        CONFIG.PF2_DEVICE_ID_mqdma {9248} \
+        CONFIG.PF3_DEVICE_ID_mqdma {9348} \
+        CONFIG.axi_data_width {256_bit} \
+        CONFIG.axilite_master_en {true} \
+        CONFIG.axisten_freq {250} \
+        CONFIG.cfg_mgmt_if {false} \
+        CONFIG.en_gt_selection {true} \
+        CONFIG.mode_selection {Advanced} \
+        CONFIG.pcie_blk_locn {PCIE4C_X0Y4} \
+        CONFIG.pf0_device_id {9048} \
+        CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} \
+        CONFIG.pl_link_cap_max_link_width {X8} \
+        CONFIG.select_quad {GTY_Quad_231} \
+        CONFIG.xdma_axi_intf_mm {AXI_Stream} \
+      ] $xdma_0
+  } else {
+     set xdma_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xdma:4.1 xdma_0 ]
+      set_property -dict [ list \
+        CONFIG.PF0_DEVICE_ID_mqdma {9048} \
+        CONFIG.PF2_DEVICE_ID_mqdma {9048} \
+        CONFIG.PF3_DEVICE_ID_mqdma {9048} \
+        CONFIG.axi_data_width {256_bit} \
+        CONFIG.axilite_master_en {true} \
+        CONFIG.axisten_freq {250} \
+        CONFIG.cfg_mgmt_if {false} \
+        CONFIG.coreclk_freq {500} \
+        CONFIG.en_gt_selection {true} \
+        CONFIG.mode_selection {Advanced} \
+        CONFIG.pcie_blk_locn {PCIE4C_X0Y4} \
+        CONFIG.pf0_device_id {9048} \
+        CONFIG.pf0_msix_cap_pba_bir {BAR_1} \
+        CONFIG.pf0_msix_cap_table_bir {BAR_1} \
+        CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} \
+        CONFIG.pl_link_cap_max_link_width {X8} \
+        CONFIG.plltype {QPLL0} \
+        CONFIG.select_quad {GTY_Quad_231} \
+        CONFIG.xdma_axi_intf_mm {AXI_Stream} \
+      ] $xdma_0
+  }
+
 
   # Create interface connections
   connect_bd_intf_net -intf_net CLK_IN_D_0_1 [get_bd_intf_ports pcie_ep_gt_ref] [get_bd_intf_pins util_ds_buf_0/CLK_IN_D]
-  connect_bd_intf_net -intf_net S00_AXIS_0_1 [get_bd_intf_ports S00_AXIS_0] [get_bd_intf_pins axis_clock_converter_0/S_AXIS]
-  connect_bd_intf_net -intf_net S00_AXI_1 [get_bd_intf_pins axi_interconnect_0/S00_AXI] [get_bd_intf_pins xdma_0/M_AXI_LITE]
+  connect_bd_intf_net -intf_net S00_AXIS_0_1 [get_bd_intf_ports S00_AXIS_0] [get_bd_intf_pins axis_dwidth_converter_0/S_AXIS]
   connect_bd_intf_net -intf_net axi_interconnect_0_M00_AXI [get_bd_intf_ports XDMA_AXI_LITE] [get_bd_intf_pins axi_interconnect_0/M00_AXI]
   connect_bd_intf_net -intf_net axis_clock_converter_0_M_AXIS [get_bd_intf_pins axis_clock_converter_0/M_AXIS] [get_bd_intf_pins xdma_0/S_AXIS_C2H_0]
+  connect_bd_intf_net -intf_net axis_dwidth_converter_0_M_AXIS [get_bd_intf_pins axis_dwidth_converter_0/M_AXIS] [get_bd_intf_pins axis_clock_converter_0/S_AXIS]
+  connect_bd_intf_net -intf_net xdma_0_M_AXI_LITE [get_bd_intf_pins xdma_0/M_AXI_LITE] [get_bd_intf_pins axi_interconnect_0/S00_AXI]
 
   # Create port connections
-  connect_bd_net -net ARESETN_1 [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_interconnect_0/S00_ARESETN] [get_bd_pins axis_clock_converter_0/m_axis_aresetn] [get_bd_pins xdma_0/axi_aresetn]
-  connect_bd_net -net M00_AXIS_ACLK_1 [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_interconnect_0/S00_ACLK] [get_bd_pins axis_clock_converter_0/m_axis_aclk] [get_bd_pins xdma_0/axi_aclk]
-  connect_bd_net -net core_clk_0_1 [get_bd_ports cpu_clk] [get_bd_pins axi_interconnect_0/M00_ACLK] [get_bd_pins axis_clock_converter_0/s_axis_aclk]
-  connect_bd_net -net m_axis_c2h_aresetn_0_1 [get_bd_ports cpu_rstn] [get_bd_pins axi_interconnect_0/M00_ARESETN] [get_bd_pins axis_clock_converter_0/s_axis_aresetn]
-  connect_bd_net -net pci_exp_rxn_0_1 [get_bd_ports pci_exp_rxn] [get_bd_pins xdma_0/pci_exp_rxn]
-  connect_bd_net -net pci_exp_rxp_0_1 [get_bd_ports pci_exp_rxp] [get_bd_pins xdma_0/pci_exp_rxp]
-  connect_bd_net -net sys_rst_n_0_1 [get_bd_ports pcie_ep_perstn] [get_bd_pins xdma_0/sys_rst_n]
-  connect_bd_net -net util_ds_buf_0_IBUF_DS_ODIV2 [get_bd_pins util_ds_buf_0/IBUF_DS_ODIV2] [get_bd_pins xdma_0/sys_clk]
-  connect_bd_net -net util_ds_buf_0_IBUF_OUT [get_bd_pins util_ds_buf_0/IBUF_OUT] [get_bd_pins xdma_0/sys_clk_gt]
-  connect_bd_net -net xdma_0_pci_exp_txn [get_bd_ports pci_exp_txn] [get_bd_pins xdma_0/pci_exp_txn]
-  connect_bd_net -net xdma_0_pci_exp_txp [get_bd_ports pci_exp_txp] [get_bd_pins xdma_0/pci_exp_txp]
-  connect_bd_net -net xdma_0_user_lnk_up [get_bd_ports pcie_ep_lnk_up] [get_bd_pins xdma_0/user_lnk_up]
+  connect_bd_net -net ARESETN_1  [get_bd_pins xdma_0/axi_aresetn] \
+  [get_bd_pins axi_interconnect_0/ARESETN] \
+  [get_bd_pins axi_interconnect_0/S00_ARESETN] \
+  [get_bd_pins axis_clock_converter_0/m_axis_aresetn]
+  connect_bd_net -net M00_AXIS_ACLK_1  [get_bd_pins xdma_0/axi_aclk] \
+  [get_bd_pins axi_interconnect_0/ACLK] \
+  [get_bd_pins axi_interconnect_0/S00_ACLK] \
+  [get_bd_pins axis_clock_converter_0/m_axis_aclk]
+  connect_bd_net -net core_clk_0_1  [get_bd_ports cpu_clk] \
+  [get_bd_pins axi_interconnect_0/M00_ACLK] \
+  [get_bd_pins axis_clock_converter_0/s_axis_aclk] \
+  [get_bd_pins axis_dwidth_converter_0/aclk]
+  connect_bd_net -net m_axis_c2h_aresetn_0_1  [get_bd_ports cpu_rstn] \
+  [get_bd_pins axi_interconnect_0/M00_ARESETN] \
+  [get_bd_pins axis_clock_converter_0/s_axis_aresetn] \
+  [get_bd_pins axis_dwidth_converter_0/aresetn]
+  connect_bd_net -net pci_exp_rxn_0_1  [get_bd_ports pci_exp_rxn] \
+  [get_bd_pins xdma_0/pci_exp_rxn]
+  connect_bd_net -net pci_exp_rxp_0_1  [get_bd_ports pci_exp_rxp] \
+  [get_bd_pins xdma_0/pci_exp_rxp]
+  connect_bd_net -net sys_rst_n_0_1  [get_bd_ports pcie_ep_perstn] \
+  [get_bd_pins xdma_0/sys_rst_n]
+  connect_bd_net -net util_ds_buf_0_IBUF_DS_ODIV2  [get_bd_pins util_ds_buf_0/IBUF_DS_ODIV2] \
+  [get_bd_pins xdma_0/sys_clk]
+  connect_bd_net -net util_ds_buf_0_IBUF_OUT  [get_bd_pins util_ds_buf_0/IBUF_OUT] \
+  [get_bd_pins xdma_0/sys_clk_gt]
+  connect_bd_net -net xdma_0_pci_exp_txn  [get_bd_pins xdma_0/pci_exp_txn] \
+  [get_bd_ports pci_exp_txn]
+  connect_bd_net -net xdma_0_pci_exp_txp  [get_bd_pins xdma_0/pci_exp_txp] \
+  [get_bd_ports pci_exp_txp]
+  connect_bd_net -net xdma_0_user_lnk_up  [get_bd_pins xdma_0/user_lnk_up] \
+  [get_bd_ports pcie_ep_lnk_up]
 
   # Create address segments
   assign_bd_address -offset 0x00000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces xdma_0/M_AXI_LITE] [get_bd_addr_segs XDMA_AXI_LITE/Reg] -force

--- a/fpga_diff/src/tcl/common/xs_uart.tcl
+++ b/fpga_diff/src/tcl/common/xs_uart.tcl
@@ -20,6 +20,7 @@
 
 set cpu "kmh"
 set cpu_candidates [list "kmh" "nanhu" "dualcore" "nutshell"]
+set vivado_version ""
 
 proc checkRequiredFiles {files} {
   set status true
@@ -64,6 +65,7 @@ proc print_help { cpu_candidates } {
   puts "$script_file -tclargs \[--cpu {$cpu_candidates}\]"
   puts "$script_file -tclargs \[--origin_dir <path>\]"
   puts "$script_file -tclargs \[--project_name <name>\]"
+  puts "$script_file -tclargs \[--vivado_version <version>\]"
   puts "$script_file -tclargs \[--help\]\n"
   puts "Usage:"
   puts "Name                   Description"
@@ -81,6 +83,7 @@ proc print_help { cpu_candidates } {
   puts "\[--project_name <name>\] Create project with the specified name. Default"
   puts "                       name is the name of the project from where this"
   puts "                       script was generated.\n"
+  puts "\[--vivado_version <version>\] Pass in the Vivado version from environment.\n"
   puts "\[--help\]               Print help information for this script"
   puts "-------------------------------------------------------------------------\n"
   exit 0
@@ -93,6 +96,7 @@ if { $::argc > 0 } {
       "--cpu"          { incr i; set cpu [lindex $::argv $i] }
       "--origin_dir"   { incr i; set origin_dir [lindex $::argv $i] }
       "--project_name" { incr i; set _xil_proj_name_ [lindex $::argv $i] }
+      "--vivado_version" { incr i; set vivado_version [lindex $::argv $i] }
       "--help"         { print_help "$cpu_candidates" }
       default {
         if { [regexp {^-} $option] } {
@@ -101,6 +105,19 @@ if { $::argc > 0 } {
         }
       }
     }
+  }
+}
+
+# Print Vivado version information if provided
+if { $vivado_version ne "" } {
+  puts "Vivado version passed from environment: $vivado_version"
+  set current_vivado_version [version -short]
+  puts "Current Vivado version: $current_vivado_version"
+  
+  if { $vivado_version ne $current_vivado_version } {
+    puts "WARNING: Version mismatch detected!"
+  } else {
+    puts "Version check: OK"
   }
 }
 
@@ -226,6 +243,10 @@ set_property -name "top_auto_set" -value "0" -objects $obj
 set_property -name "top_lib" -value "xil_defaultlib" -objects $obj
 
 # Create BD cdc_ddr4
+if { [info exists vivado_version] } {
+    set ::vivado_version $vivado_version
+}
+
 # source "$tcl_dir/cdc_ddr4.tcl"
 
 # Create BD for JTAG and DDR4 Subsystem


### PR DESCRIPTION
When the environment Vivado is detected as 2025, select the IP corresponding to 2025 when generating the project.