### PR TITLE
feat(fpga_diff): support async_clock for difftest axis

### DIFF
--- a/fpga_diff/src/constr/common/fpga.xdc
+++ b/fpga_diff/src/constr/common/fpga.xdc
@@ -442,7 +442,7 @@ set_property IOSTANDARD LVCMOS18 [get_ports PHY_RESET_B]
 create_clock -period 400.000 -name mdc_clk [get_ports MDC]
 create_clock -period 5.000 -name CPU_CLK_IN [get_ports clk6_p]
 create_clock -period 1000.000 -name TMCLK [get_ports clk8_p]
-create_clock -period 20.000 -name DEBUG_CLK_IN [get_ports clk5_p]
+create_clock -period 40.000 -name DEBUG_CLK_IN [get_ports clk5_p]
 create_clock -period 10.000 -name PCIE_CLK_IN [get_ports refclk_p]
 create_clock -period 10.000 -name PCIE2_CLK_IN [get_ports refclk2_p]
 create_clock -period 83.333 -name jtag_vclk [get_ports JTAG_TCK]
@@ -475,6 +475,11 @@ set_property PULLUP true [get_ports SD_DATA2]
 set_property PULLUP true [get_ports SD_DATA3]
 set_property PULLUP true [get_ports MDC]
 set_property PULLUP true [get_ports MDIO]
+
+####################################################################################
+# Constraints for difftest_pcie_clock from CLK_WIZ
+####################################################################################
+set_clock_groups -asynchronous -group [get_clocks difftest_pcie_clock] -group [get_clocks DEBUG_CLK_IN]
 
 ####################################################################################
 # Constraints from file : 'jtag_ddr_subsys_s01_data_fifo_0_clocks.xdc'

--- a/fpga_diff/src/rtl/common/core_def_xdma.sv
+++ b/fpga_diff/src/rtl/common/core_def_xdma.sv
@@ -1074,6 +1074,7 @@ assign i2c2_prdata = 0;
   wire clock_enable;
   wire sys_rstn_io;
   wire cpu_rstn_io;
+  wire difftest_pcie_clock;
   assign sys_rstn_io = sys_rstn & ~host_io_reset;
   assign cpu_rstn_io = cpu_rstn & ~host_io_reset;
 
@@ -1109,6 +1110,7 @@ assign i2c2_prdata = 0;
     .XDMA_AXI_LITE_rvalid (XDMA_AXI_LITE_rvalid),
     .XDMA_AXI_LITE_rready (XDMA_AXI_LITE_rready),
     
+    .TO_DIFFTEST_PCIE_CLK (difftest_pcie_clock),
     .pci_exp_rxn(pci_ep_rxn),
     .pci_exp_rxp(pci_ep_rxp),
     .pci_exp_txn(pci_ep_txn),
@@ -1269,6 +1271,7 @@ jtag_ddr_subsys_wrapper U_JTAG_DDR_SUBSYS(
 );
 
 SimTop_wrapper U_CPU_TOP(
+    .difftest_pcie_clock             (difftest_pcie_clock),
     .difftest_to_host_axis_ready     (difftest_to_host_axis_ready),
     .difftest_to_host_axis_valid     (difftest_to_host_axis_valid),
     .difftest_to_host_axis_bits_data (difftest_to_host_axis_bits_data),

--- a/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
+++ b/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
@@ -158,6 +158,7 @@ output io_riscv_halt_0,
 output io_riscv_halt_1,
 
 input          difftest_ref_clock,
+               difftest_pcie_clock,
                difftest_to_host_axis_ready,
 output         difftest_to_host_axis_valid,
 output [511:0] difftest_to_host_axis_bits_data,
@@ -342,6 +343,7 @@ SimTop  u_XSTop(
 
   //difftest
   .difftest_ref_clock              (difftest_ref_clock),
+  .difftest_pcie_clock             (difftest_pcie_clock),
   .difftest_to_host_axis_ready     (difftest_to_host_axis_ready),
   .difftest_to_host_axis_valid     (difftest_to_host_axis_valid),
   .difftest_to_host_axis_bits_data (difftest_to_host_axis_bits_data),

--- a/fpga_diff/src/rtl/nanhu/SimTop_wrapper.sv
+++ b/fpga_diff/src/rtl/nanhu/SimTop_wrapper.sv
@@ -176,6 +176,7 @@ output io_riscv_halt_0,
 output io_riscv_halt_1,
 
 input          difftest_ref_clock,
+               difftest_pcie_clock,
                difftest_to_host_axis_ready,
 output         difftest_to_host_axis_valid,
 output [511:0] difftest_to_host_axis_bits_data,
@@ -389,6 +390,7 @@ XlnFpgaTop  XlnFpgaTop_inst(
   .s_axi_hs_rlast                  (dma_core_rlast),
 
   //difftest
+  .difftest_pcie_clock             (difftest_pcie_clock),
   .difftest_ref_clock              (difftest_ref_clock),
   .difftest_to_host_axis_ready     (difftest_to_host_axis_ready),
   .difftest_to_host_axis_valid     (difftest_to_host_axis_valid),

--- a/fpga_diff/src/rtl/nutshell/SimTop_wrapper.sv
+++ b/fpga_diff/src/rtl/nutshell/SimTop_wrapper.sv
@@ -143,6 +143,7 @@ module SimTop_wrapper(
   (*mark_debug="true"*) input           mem_core_rlast,
 
 input          difftest_ref_clock,
+               difftest_pcie_clock,
                difftest_to_host_axis_ready,
 output         difftest_to_host_axis_valid,
 output [511:0] difftest_to_host_axis_bits_data,
@@ -300,6 +301,7 @@ SimTop u_SimTop (
 
     // difftest
     .difftest_ref_clock              (difftest_ref_clock),
+    .difftest_pcie_clock             (difftest_pcie_clock),
     .difftest_to_host_axis_ready     (difftest_to_host_axis_ready),
     .difftest_to_host_axis_valid     (difftest_to_host_axis_valid),
     .difftest_to_host_axis_bits_data (difftest_to_host_axis_bits_data),

--- a/fpga_diff/src/tcl/common/AXI_bridge.tcl
+++ b/fpga_diff/src/tcl/common/AXI_bridge.tcl
@@ -196,7 +196,7 @@ proc create_root_design { parentCell } {
    CONFIG.AWUSER_WIDTH {0} \
    CONFIG.BUSER_WIDTH {0} \
    CONFIG.DATA_WIDTH {64} \
-   CONFIG.FREQ_HZ {50000000} \
+   CONFIG.FREQ_HZ {25000000} \
    CONFIG.HAS_BRESP {1} \
    CONFIG.HAS_BURST {1} \
    CONFIG.HAS_CACHE {1} \
@@ -229,7 +229,7 @@ proc create_root_design { parentCell } {
   set_property -dict [ list \
    CONFIG.ADDR_WIDTH {32} \
    CONFIG.DATA_WIDTH {32} \
-   CONFIG.FREQ_HZ {50000000} \
+   CONFIG.FREQ_HZ {25000000} \
    CONFIG.HAS_BURST {0} \
    CONFIG.HAS_CACHE {0} \
    CONFIG.HAS_LOCK {0} \
@@ -243,12 +243,12 @@ proc create_root_design { parentCell } {
 
 
   # Create ports
-  set ACLK [ create_bd_port -dir I -type clk -freq_hz 50000000 ACLK ]
+  set ACLK [ create_bd_port -dir I -type clk -freq_hz 25000000 ACLK ]
   set_property -dict [ list \
    CONFIG.ASSOCIATED_BUSIF {rom_axi} \
  ] $ACLK
   set ARESETN [ create_bd_port -dir I -type rst ARESETN ]
-  set SYS_INTER_CLK [ create_bd_port -dir I -type clk -freq_hz 50000000 SYS_INTER_CLK ]
+  set SYS_INTER_CLK [ create_bd_port -dir I -type clk -freq_hz 25000000 SYS_INTER_CLK ]
   set_property -dict [ list \
    CONFIG.ASSOCIATED_BUSIF {S00_AXI} \
  ] $SYS_INTER_CLK

--- a/fpga_diff/src/tcl/common/jtag_ddr_subsys.tcl
+++ b/fpga_diff/src/tcl/common/jtag_ddr_subsys.tcl
@@ -211,7 +211,7 @@ proc create_root_design { parentCell } {
    CONFIG.AWUSER_WIDTH {0} \
    CONFIG.BUSER_WIDTH {0} \
    CONFIG.DATA_WIDTH $SOC_M_AXI_DATA_WIDTH \
-   CONFIG.FREQ_HZ {50000000} \
+   CONFIG.FREQ_HZ {25000000} \
    CONFIG.HAS_BRESP {1} \
    CONFIG.HAS_BURST {1} \
    CONFIG.HAS_CACHE {1} \
@@ -242,7 +242,7 @@ proc create_root_design { parentCell } {
   set_property -dict [ list \
    CONFIG.FREQ_HZ {25000000} \
  ] $MAC_CLK
-  set SOC_CLK [ create_bd_port -dir I -type clk -freq_hz 50000000 SOC_CLK ]
+  set SOC_CLK [ create_bd_port -dir I -type clk -freq_hz 25000000 SOC_CLK ]
   set_property -dict [ list \
    CONFIG.ASSOCIATED_BUSIF {SOC_M_AXI} \
  ] $SOC_CLK

--- a/fpga_diff/src/tcl/common/pcie_axi_axis_bd.tcl
+++ b/fpga_diff/src/tcl/common/pcie_axi_axis_bd.tcl
@@ -196,7 +196,7 @@ proc create_root_design { parentCell } {
    CONFIG.AWUSER_WIDTH {0} \
    CONFIG.BUSER_WIDTH {0} \
    CONFIG.DATA_WIDTH {256} \
-   CONFIG.FREQ_HZ {50000000} \
+   CONFIG.FREQ_HZ {25000000} \
    CONFIG.HAS_BRESP {1} \
    CONFIG.HAS_BURST {1} \
    CONFIG.HAS_CACHE {1} \
@@ -230,7 +230,7 @@ proc create_root_design { parentCell } {
   set_property -dict [ list \
    CONFIG.ADDR_WIDTH {40} \
    CONFIG.DATA_WIDTH {256} \
-   CONFIG.FREQ_HZ {50000000} \
+   CONFIG.FREQ_HZ {25000000} \
    CONFIG.HAS_REGION {0} \
    CONFIG.NUM_READ_OUTSTANDING {2} \
    CONFIG.NUM_WRITE_OUTSTANDING {2} \
@@ -253,7 +253,7 @@ proc create_root_design { parentCell } {
 
 
   # Create ports
-  set main_clk [ create_bd_port -dir I -type clk -freq_hz 50000000 main_clk ]
+  set main_clk [ create_bd_port -dir I -type clk -freq_hz 25000000 main_clk ]
   set main_rst_n [ create_bd_port -dir I -type rst main_rst_n ]
   set user_clk [ create_bd_port -dir I -type clk -freq_hz 125000000 user_clk ]
   set_property -dict [ list \


### PR DESCRIPTION
To reduce timing pressure and lower the CPU clock frequency to 25 MHz without affecting the transmission performance, the data of difftest is read using the AXI CLK of XDMA.