### PR TITLE
fpga_diff: fix xdma c2h reset and release

### DIFF
--- a/fpga_diff/src/constr/common/debug.xdc
+++ b/fpga_diff/src/constr/common/debug.xdc
@@ -7,6 +7,15 @@ set_false_path -from [get_clocks -of_objects [get_pins xs_core_def/U_JTAG_DDR_SU
 ####################################################################################
 
 set_false_path -from [get_clocks -of_objects [get_pins xs_core_def/U_JTAG_DDR_SUBSYS/jtag_ddr_subsys_i/ddr4_0/inst/u_ddr4_infrastructure/gen_mmcme4.u_mmcme_adv_inst/CLKOUT1]] -to [get_clocks -of_objects [get_pins xs_core_def/u0_xdma/xdma_0/inst/pcie4c_ip_i/inst/xdma_xdma_0_0_pcie4c_ip_gt_top_i/diablo_gt.diablo_gt_phy_wrapper/phy_clk_i/bufg_gt_userclk/O]]
+
+####################################################################################
+# C2H bridge async reset CDC (Attempt 6 c2h_rstn path)
+# xpm_cdc_async_rst synchronizes c2h_rstn from sys_clk_i to PCIe-derived clock.
+# The AND-gated output feeds async reset of axis_clock/dwidth_converter.
+# This is an inherently async reset path — exclude from setup/hold analysis.
+####################################################################################
+set_false_path -through [get_nets {core_def/xdma_ep_i/xpm_cdc_gen_0/inst/xarst/arststages_ff[1]}]
+
 set_property C_CLK_INPUT_FREQ_HZ 300000000 [get_debug_cores dbg_hub]
 set_property C_ENABLE_CLK_DIVIDER false [get_debug_cores dbg_hub]
 set_property C_USER_SCAN_CHAIN 1 [get_debug_cores dbg_hub]

--- a/fpga_diff/src/rtl/common/core_def_xdma.sv
+++ b/fpga_diff/src/rtl/common/core_def_xdma.sv
@@ -1235,10 +1235,17 @@ wire [0:0]    br2cfg_wvalid;
   wire clock_enable;
   wire sys_rstn_io;
   wire cpu_rstn_io;
+  wire difftest_c2h_rstn;
+  wire difftest_stream_enable;
+  wire difftest_startup_done;
+  reg [19:0] difftest_startup_wait;
 
   wire difftest_pcie_clock;
   assign sys_rstn_io = sys_rstn & ~io_host_reset;
   assign cpu_rstn_io = cpu_rstn & ~io_host_reset;
+  assign difftest_startup_done = &difftest_startup_wait;
+  assign difftest_stream_enable = xdma_link_up & io_host_diff_enable & difftest_startup_done;
+  assign difftest_c2h_rstn = cpu_rstn_io & difftest_stream_enable;
   assign noc_clk = inter_soc_clk;
 
   reg [1:0] pcie_lnk_sync;
@@ -1248,12 +1255,20 @@ wire [0:0]    br2cfg_wvalid;
   end
   wire xdma_link_up = pcie_lnk_sync[1];
 
-  assign difftest_to_host_axis_ready = difftest_to_host_axis_ready_io & xdma_link_up;
-  assign difftest_to_host_axis_valid_io = difftest_to_host_axis_valid & xdma_link_up & io_host_diff_enable;
+  always @(posedge sys_clk_i) begin
+      if (!cpu_rstn_io || !io_host_diff_enable || !xdma_link_up)
+          difftest_startup_wait <= 20'b0;
+      else if (!difftest_startup_done)
+          difftest_startup_wait <= difftest_startup_wait + 20'b1;
+  end
+
+  assign difftest_to_host_axis_ready = difftest_to_host_axis_ready_io & difftest_stream_enable;
+  assign difftest_to_host_axis_valid_io = difftest_to_host_axis_valid & difftest_stream_enable;
 
   xdma_ep xdma_ep_i(
     .cpu_clk(sys_clk_i),
     .cpu_rstn(sys_rstn),
+    .c2h_rstn(difftest_c2h_rstn),
     .S00_AXIS_0_tdata(difftest_to_host_axis_bits_data),
     .S00_AXIS_0_tkeep(64'hffffffff_ffffffff),
     .S00_AXIS_0_tlast(difftest_to_host_axis_bits_last),

--- a/fpga_diff/src/tcl/common/xdma_ep.tcl
+++ b/fpga_diff/src/tcl/common/xdma_ep.tcl
@@ -136,6 +136,7 @@ if { $bCheckIPs == 1 } {
   set list_check_ips [list \
     xilinx.com:ip:axis_clock_converter:1.1\
     xilinx.com:ip:axis_dwidth_converter:1.1\
+    xilinx.com:ip:util_vector_logic:2.0\
     xilinx.com:ip:xpm_cdc_gen:1.0\
     xilinx.com:ip:clk_wiz:6.0\
     $util_vlnv\
@@ -236,6 +237,7 @@ proc create_root_design { parentCell } {
 
   # Create ports
   set cpu_rstn [ create_bd_port -dir I -type rst cpu_rstn ]
+  set c2h_rstn [ create_bd_port -dir I -type rst c2h_rstn ]
   set pci_exp_rxn [ create_bd_port -dir I -from 7 -to 0 pci_exp_rxn ]
   set pci_exp_rxp [ create_bd_port -dir I -from 7 -to 0 pci_exp_rxp ]
   set pci_exp_txn [ create_bd_port -dir O -from 7 -to 0 pci_exp_txn ]
@@ -331,6 +333,14 @@ proc create_root_design { parentCell } {
    CONFIG.WIDTH {1} \
  ] $xpm_cdc_gen_0
 
+  # Create instance: logic_and_c2h_rst, and set properties
+  set logic_and_c2h_rst [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_vector_logic:2.0 logic_and_c2h_rst ]
+  set_property -dict [ list \
+   CONFIG.C_OPERATION {and} \
+   CONFIG.C_SIZE {1} \
+   CONFIG.LOGO_FILE {data/sym_andgate.png} \
+ ] $logic_and_c2h_rst
+
   # Create instance: axis_dwidth_converter_0, and set properties
   set axis_dwidth_converter_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_dwidth_converter:1.1 axis_dwidth_converter_0 ]
   set_property CONFIG.M_TDATA_NUM_BYTES {32} $axis_dwidth_converter_0
@@ -351,8 +361,7 @@ proc create_root_design { parentCell } {
   connect_bd_net -net ARESETN_1  [get_bd_pins xdma_0/axi_aresetn] \
   [get_bd_pins axi_interconnect_0/ARESETN] \
   [get_bd_pins axi_interconnect_0/S00_ARESETN] \
-  [get_bd_pins axis_clock_converter_0/m_axis_aresetn] \
-  [get_bd_pins axis_dwidth_converter_0/aresetn] \
+  [get_bd_pins logic_and_c2h_rst/Op1] \
   [get_bd_pins clk_wiz_0/resetn]
   connect_bd_net -net M00_AXIS_ACLK_1  [get_bd_pins xdma_0/axi_aclk] \
   [get_bd_pins axi_interconnect_0/ACLK] \
@@ -367,7 +376,8 @@ proc create_root_design { parentCell } {
   connect_bd_net -net cpu_clk_1  [get_bd_ports cpu_clk] \
   [get_bd_pins axi_interconnect_0/M00_ACLK]
   connect_bd_net -net m_axis_c2h_aresetn_0_1  [get_bd_ports cpu_rstn] \
-  [get_bd_pins axi_interconnect_0/M00_ARESETN] \
+  [get_bd_pins axi_interconnect_0/M00_ARESETN]
+  connect_bd_net -net c2h_rstn_0_1  [get_bd_ports c2h_rstn] \
   [get_bd_pins xpm_cdc_gen_0/src_arst]
   connect_bd_net -net pci_exp_rxn_0_1  [get_bd_ports pci_exp_rxn] \
   [get_bd_pins xdma_0/pci_exp_rxn]
@@ -386,7 +396,11 @@ proc create_root_design { parentCell } {
   connect_bd_net -net xdma_0_user_lnk_up  [get_bd_pins xdma_0/user_lnk_up] \
   [get_bd_ports pcie_ep_lnk_up]
   connect_bd_net -net xpm_cdc_gen_0_dest_arst  [get_bd_pins xpm_cdc_gen_0/dest_arst] \
-  [get_bd_pins axis_clock_converter_0/s_axis_aresetn]
+  [get_bd_pins axis_clock_converter_0/s_axis_aresetn] \
+  [get_bd_pins logic_and_c2h_rst/Op2]
+  connect_bd_net -net logic_and_c2h_rst_Res  [get_bd_pins logic_and_c2h_rst/Res] \
+  [get_bd_pins axis_clock_converter_0/m_axis_aresetn] \
+  [get_bd_pins axis_dwidth_converter_0/aresetn]
 
   # Create address segments
   assign_bd_address -offset 0x00000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces xdma_0/M_AXI_LITE] [get_bd_addr_segs XDMA_AXI_LITE/Reg] -force
@@ -408,4 +422,3 @@ create_root_design ""
 
 
 common::send_gid_msg -ssname BD::TCL -id 2053 -severity "WARNING" "This Tcl script was generated from a block design that has not been validated. It is possible that design <$design_name> may result in errors during validation."
-


### PR DESCRIPTION
Before this change, repeated fpga_diff runs could alternate between good and bad states because the XDMA C2H stream could start from stale data or an unstable packet boundary.

Fix the C2H reset sequence by:
- adding a dedicated c2h_rstn for the XDMA C2H AXIS bridge
- resetting only the C2H clock/data-width converters, not the AXI-Lite control path
- delaying C2H release and stream valid/ready until the host read path is stable

A reset-only attempt reduced stale-tail symptoms but made fresh runs sensitive;
a delay-only attempt did not clear stale data across runs. The combined sequence
This change passes fresh and consecutive MicroBench runs with the original fpga-host.