### PR TITLE
fpga_diff: avoid reset_ddr after every write_jtag_ddr

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -1,5 +1,8 @@
 ENV_SCRIPTS_HOME ?= $(CURDIR)
 
+# Ensure Vivado can run on hosts with non-C locales (e.g. zh_CN.UTF-8)
+export LC_ALL := C
+
 CORE_DIR ?=
 CHI_DIR ?=
 FPGA_BIT_HOME ?=
@@ -51,18 +54,25 @@ check_version:
 	vivado -mode batch -source src/tcl/common/check_version.tcl -tclargs --vivado_version $(VIVADO_VERSION) --cpu $(CPU) --project_name $(PRJ_NAME)
 
 # Write bitstream to FPGA via PCIe
+# After programming, reset DDR controller (sw4 toggle) for initial calibration.
 write_bitstream:
 	sh tools/pcie-remove.sh
 	vivado -mode tcl -source tools/write_bitstream.tcl -tclargs $(FPGA_BIT_HOME)
 	sh tools/pcie-rescan.sh
+	vivado -mode tcl -source tools/reset_ddr.tcl -tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
 
 # Write workload to FPGA DDR via JTAG
+# The jtag_write_ddr.tcl script halts the system (sw6=0) before writing DDR,
+# then reset_cpu releases the CPU. No DDR controller reset (sw4 toggle) is
+# performed here — DDR4 MIG warm reset causes unreliable PHY recalibration.
 write_jtag_ddr:
-	vivado -mode tcl -source tools/reset_ddr.tcl -tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
-	vivado -mode tcl -source tools/jtag_write_ddr.tcl -tclargs $(WORKLOAD) $(AXI_WIDTH)
+	vivado -mode tcl -source tools/jtag_write_ddr.tcl -tclargs $(WORKLOAD) $(AXI_WIDTH) $(FPGA_BIT_HOME)/fpga_top_debug.ltx
 	$(MAKE) reset_cpu
 
 # Reset CPU on FPGA
+# Note: reset_cpu.tcl toggles vio_sw6 which also resets XDMA IP (sys_rstn = sys_rstn && vio_sw6).
+# This briefly drops the PCIe link, but the XDMA driver recovers on its own.
+# Do NOT add pcie-remove/rescan here — it causes a second link disruption and corrupts XDMA state.
 reset_cpu:
 	vivado -mode tcl -source tools/reset_cpu.tcl -tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
 

--- a/fpga_diff/tools/jtag_write_ddr.tcl
+++ b/fpga_diff/tools/jtag_write_ddr.tcl
@@ -1,6 +1,15 @@
 puts "workload path:"
 puts [lindex $argv 0]
 set file_name [lindex $argv 0]
+
+# 3rd argument: .ltx probe file path for VIO halt (sw6=0)
+set ltx_file [lindex $argv 2]
+if {$ltx_file eq "" || ![file exists $ltx_file]} {
+    puts "ERROR: .ltx probe file required as 3rd argument"
+    puts "Usage: jtag_write_ddr.tcl <workload.txt> <axi_width> <probes.ltx>"
+    exit 1
+}
+
 # Initialize LabTools system
 if {[catch {open_hw_manager} errmsg]} {
     puts "Error initializing LabTools system: $errmsg"
@@ -37,6 +46,19 @@ if {$hw_device eq ""} {
 }
 puts "Refreshing hardware device..."
 refresh_hw_device $hw_device
+
+# Halt system (sw6=0) before DDR write to prevent CPU from modifying DDR.
+# This avoids the need for a separate reset_ddr.tcl call (and its destructive
+# DDR controller warm-reset via sw4 toggle).
+puts "Loading probes from $ltx_file for system halt..."
+set_property PROBES.FILE $ltx_file [current_hw_device]
+refresh_hw_device [current_hw_device]
+refresh_hw_vio hw_vio_1
+# vio_sw6 0 (halt system)
+set_property OUTPUT_VALUE 0 [get_hw_probes vio_sw6 -of_objects [get_hw_vios hw_vio_1]]
+commit_hw_vio [get_hw_probes {vio_sw6} -of_objects [get_hw_vios hw_vio_1]]
+puts "System halted (sw6=0)"
+after 500
 
 # List all AXI interfaces
 set hw_axi_list [get_hw_axis]
@@ -180,10 +202,11 @@ proc write_to_ddr {fn hw_axi hw_axi_data_width} {
     }
   }
   close $fdata
-  exit
 }
 
 if {[catch {[write_to_ddr $file_name $hw_axi $hw_axi_data_width]} errmsg]} {
   puts "ErrorMsg: $errmsg"
 }
 puts "After"
+
+exit


### PR DESCRIPTION
This change move reset_ddr from write_jtag_ddr to after write_bitstream, so as to avoid write_jtag_ddr error on ddr warm reset.