### PR TITLE
fpga_diff: refactor write_ddr and fpga-host flow

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -55,12 +55,15 @@ write_bitstream:
 	sh tools/pcie-remove.sh
 	vivado -mode tcl -source tools/write_bitstream.tcl -tclargs $(FPGA_BIT_HOME)
 	sh tools/pcie-rescan.sh
+	vivado -mode tcl -source tools/reset_ddr.tcl -tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
+
+# Halt the FPGA SoC (for Write Jtag DDR)
+halt_soc:
+	vivado -mode tcl -source tools/halt_soc.tcl -tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
 
 # Write workload to FPGA DDR via JTAG
 write_jtag_ddr:
-	vivado -mode tcl -source tools/reset_ddr.tcl -tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
 	vivado -mode tcl -source tools/jtag_write_ddr.tcl -tclargs $(WORKLOAD) $(AXI_WIDTH)
-	$(MAKE) reset_cpu
 
 # Reset CPU on FPGA
 reset_cpu:

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -20,6 +20,32 @@ Core RTL to FPGA Steps
 
 6. make write_bitstream
 
-7. make write_jtag_ddr
+7. write DDR and run with diff/no-diff
+```shell
+case 1: No fpga-host
+stty -F /dev/ttyUSB0 raw 115200 ...
+<New terminal>
+make halt_soc
+make write_jtag_ddr
+make reset_cpu
 
-8. run difftest-host
+case 2: With fpga-host (no-diff mode)
+FPGA_DDR_LOAD_CMD="bash -lc ' \
+  source ~/.bash_profile && \
+  make -C /path/to/fpga_diff write_jtag_ddr \
+    FPGA_BIT_HOME=... \
+    WORKLOAD=<workload>.txt \
+'" \
+./fpga-host --no-diff
+
+case 3: With fpga-host (diff mode)
+FPGA_DDR_LOAD_CMD="bash -lc ' \
+  source ~/.bash_profile && \
+  make -C /path/to/fpga_diff write_jtag_ddr \
+    FPGA_BIT_HOME=... \
+    WORKLOAD=<workload>.txt \
+'" \
+./fpga-host --diff <nemu> -i <workload>.bin
+```
+
+

--- a/fpga_diff/tools/halt_soc.tcl
+++ b/fpga_diff/tools/halt_soc.tcl
@@ -1,0 +1,27 @@
+puts "probe .ltx path:"
+puts [lindex $argv 0]
+set file_name [lindex $argv 0]
+
+if {![file exists $file_name]} {
+    puts "ERROR: .ltx file not found: $file_name"
+    exit 1
+}
+
+open_hw_manager
+connect_hw_server
+open_hw_target
+
+current_hw_device [get_hw_devices *]
+
+# load .ltx file
+set_property PROBES.FILE $file_name [current_hw_device]
+
+refresh_hw_device [current_hw_device]
+refresh_hw_vio hw_vio_1
+
+puts [get_hw_probes -of_objects [get_hw_vios hw_vio_1]]
+# vio_sw6 0
+set_property OUTPUT_VALUE 0 [get_hw_probes vio_sw6 -of_objects [get_hw_vios hw_vio_1]]
+commit_hw_vio [get_hw_probes {vio_sw6} -of_objects [get_hw_vios hw_vio_1]]
+puts [get_property OUTPUT_VALUE  [get_hw_probes -of_objects [get_hw_vios hw_vio_1]]]
+exit


### PR DESCRIPTION
This change move reset_ddr from write_jtag_ddr to after write_bitstream, so as to avoid write_jtag_ddr error on ddr warm reset.

Note:
1. DDR should only be written when cpu/soc halted. We can only write DDR when fpga-host halt with io_reset or no-host halt with tcl.
2. Workload(such as linux) may modify DDR itself. So we should write DDR every time before running.

There is 2 ways recommended with/without fpga-host

case 1: no fpga-host (Halt soc with tcl)
  halt_soc -> write_ddr -> reset_cpu

case 2: with fpga-host (Halt cpu with host-writed register)
  host_reset 1 -> write_ddr -> host_reset 0
  example: FPGA_DDR_LOAD_CMD=.. && ./fpga-host