### PR TITLE
fix(fpga_diff): correct JTAG flash burst order

### DIFF
--- a/fpga_diff/tools/jtag_write_flash.tcl
+++ b/fpga_diff/tools/jtag_write_flash.tcl
@@ -162,7 +162,8 @@ proc write_flash {bytes hw_axi base_addr max_len} {
     }
 
     set data_hex ""
-    for {set i 0} {$i < $chunk_len} {incr i} {
+    # Vivado maps the rightmost data beat to the lowest INCR address.
+    for {set i [expr {$chunk_len - 1}]} {$i >= 0} {incr i -1} {
       append data_hex [word_hex $bytes [expr {($word_index + $i) * $beat_bytes}]]
     }
 


### PR DESCRIPTION
## Summary

Vivado assigns the rightmost data beat to the lowest address of an INCR transaction. Pack each flash burst in reverse textual order so binary words retain ascending memory addresses.

The byte order within each 32-bit word is unchanged.

## Validation

- ran the complete Tcl writer with mocked Vivado hardware commands
- wrote the 10068-byte bootrom-noprint.bin using 256-word bursts
- passed first, middle, and final sample readback checks
- confirmed address 0x10000000 contains the first instruction 0x00000413