### PR TITLE
feat(fpga_diff): add 32KB boot SRAM for extLLC

### DIFF
--- a/fpga_diff/src/tcl/common/AXI_bridge.tcl
+++ b/fpga_diff/src/tcl/common/AXI_bridge.tcl
@@ -122,12 +122,14 @@ set bCheckIPsPassed 1
 ##################################################################
 set bCheckIPs 1
 if { $bCheckIPs == 1 } {
-   set list_check_ips "\ 
-xilinx.com:ip:axi_apb_bridge:3.0\
-xilinx.com:ip:axi_uart16550:2.0\
-xilinx.com:ip:jtag_axi:1.2\
-xilinx.com:ip:xlconstant:1.1\
-"
+   set list_check_ips {
+      xilinx.com:ip:axi_apb_bridge:3.0
+      xilinx.com:ip:axi_bram_ctrl:4.1
+      xilinx.com:ip:axi_uart16550:2.0
+      xilinx.com:ip:blk_mem_gen:8.4
+      xilinx.com:ip:jtag_axi:1.2
+      xilinx.com:ip:xlconstant:1.1
+   }
 
    set list_ips_missing ""
    common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
@@ -265,9 +267,29 @@ proc create_root_design { parentCell } {
   # Create instance: axi_interconnect_0, and set properties
   set axi_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_interconnect_0 ]
   set_property -dict [ list \
-   CONFIG.NUM_MI {3} \
+   CONFIG.NUM_MI {4} \
    CONFIG.NUM_SI {2} \
  ] $axi_interconnect_0
+
+  # Create instance: extllc_bram_ctrl, and set properties
+  set extllc_bram_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl:4.1 extllc_bram_ctrl ]
+  set_property -dict [ list \
+   CONFIG.DATA_WIDTH {64} \
+   CONFIG.ECC_TYPE {0} \
+   CONFIG.SINGLE_PORT_BRAM {1} \
+ ] $extllc_bram_ctrl
+
+  # Create instance: extllc_bram, and set properties
+  set extllc_bram [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 extllc_bram ]
+  set_property -dict [ list \
+   CONFIG.Byte_Size {8} \
+   CONFIG.Load_Init_File {false} \
+   CONFIG.Memory_Type {Single_Port_RAM} \
+   CONFIG.Read_Width_A {64} \
+   CONFIG.Use_Byte_Write_Enable {true} \
+   CONFIG.Write_Depth_A {4096} \
+   CONFIG.Write_Width_A {64} \
+ ] $extllc_bram
 
   # Create instance: axi_uart16550_0, and set properties
   set axi_uart16550_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_uart16550:2.0 axi_uart16550_0 ]
@@ -297,12 +319,14 @@ proc create_root_design { parentCell } {
   connect_bd_intf_net -intf_net axi_interconnect_0_M01_AXI [get_bd_intf_pins axi_interconnect_0/M01_AXI] [get_bd_intf_pins axi_uart16550_0/S_AXI]
   set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets axi_interconnect_0_M01_AXI]
   connect_bd_intf_net -intf_net axi_interconnect_0_M02_AXI [get_bd_intf_ports rom_axi] [get_bd_intf_pins axi_interconnect_0/M02_AXI]
+  connect_bd_intf_net -intf_net axi_interconnect_0_M03_AXI [get_bd_intf_pins axi_interconnect_0/M03_AXI] [get_bd_intf_pins extllc_bram_ctrl/S_AXI]
+  connect_bd_intf_net -intf_net extllc_bram_ctrl_BRAM_PORTA [get_bd_intf_pins extllc_bram_ctrl/BRAM_PORTA] [get_bd_intf_pins extllc_bram/BRAM_PORTA]
   connect_bd_intf_net -intf_net jtag_axi_flash_M_AXI [get_bd_intf_pins axi_interconnect_0/S01_AXI] [get_bd_intf_pins jtag_axi_flash/M_AXI]
   connect_bd_intf_net -intf_net axi_uart16550_0_UART [get_bd_intf_ports UART_0] [get_bd_intf_pins axi_uart16550_0/UART]
 
   # Create port connections
-  connect_bd_net -net ACLK_0_1 [get_bd_ports ACLK] [get_bd_pins axi_apb_bridge_0/s_axi_aclk] [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_interconnect_0/M00_ACLK] [get_bd_pins axi_interconnect_0/M01_ACLK] [get_bd_pins axi_interconnect_0/M02_ACLK] [get_bd_pins axi_interconnect_0/S01_ACLK] [get_bd_pins axi_uart16550_0/s_axi_aclk] [get_bd_pins jtag_axi_flash/aclk]
-  connect_bd_net -net ARESETN_0_1 [get_bd_ports ARESETN] [get_bd_pins axi_apb_bridge_0/s_axi_aresetn] [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_interconnect_0/M00_ARESETN] [get_bd_pins axi_interconnect_0/M01_ARESETN] [get_bd_pins axi_interconnect_0/M02_ARESETN] [get_bd_pins axi_interconnect_0/S00_ARESETN] [get_bd_pins axi_interconnect_0/S01_ARESETN] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins jtag_axi_flash/aresetn]
+  connect_bd_net -net ACLK_0_1 [get_bd_ports ACLK] [get_bd_pins axi_apb_bridge_0/s_axi_aclk] [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_interconnect_0/M00_ACLK] [get_bd_pins axi_interconnect_0/M01_ACLK] [get_bd_pins axi_interconnect_0/M02_ACLK] [get_bd_pins axi_interconnect_0/M03_ACLK] [get_bd_pins axi_interconnect_0/S01_ACLK] [get_bd_pins axi_uart16550_0/s_axi_aclk] [get_bd_pins extllc_bram_ctrl/s_axi_aclk] [get_bd_pins jtag_axi_flash/aclk]
+  connect_bd_net -net ARESETN_0_1 [get_bd_ports ARESETN] [get_bd_pins axi_apb_bridge_0/s_axi_aresetn] [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_interconnect_0/M00_ARESETN] [get_bd_pins axi_interconnect_0/M01_ARESETN] [get_bd_pins axi_interconnect_0/M02_ARESETN] [get_bd_pins axi_interconnect_0/M03_ARESETN] [get_bd_pins axi_interconnect_0/S00_ARESETN] [get_bd_pins axi_interconnect_0/S01_ARESETN] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins extllc_bram_ctrl/s_axi_aresetn] [get_bd_pins jtag_axi_flash/aresetn]
   connect_bd_net -net SYS_INTER_CLK_1 [get_bd_ports SYS_INTER_CLK] [get_bd_pins axi_interconnect_0/S00_ACLK]
   connect_bd_net -net axi_uart16550_0_ip2intc_irpt [get_bd_ports uart0_intc] [get_bd_pins axi_uart16550_0/ip2intc_irpt]
   connect_bd_net -net xlconstant_0_dout [get_bd_pins axi_uart16550_0/freeze] [get_bd_pins xlconstant_0/dout]
@@ -311,9 +335,11 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0x31200000 -range 0x00010000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs SYS_CFG_APB/Reg] -force
   assign_bd_address -offset 0x310B0000 -range 0x00010000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg] -force
   assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs rom_axi/Reg] -force
+  assign_bd_address -offset 0x37F00000 -range 0x00008000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs extllc_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x10000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs rom_axi/Reg] -force
   exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs SYS_CFG_APB/Reg]
   exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs extllc_bram_ctrl/S_AXI/Mem0]
 
 
   # Restore current instance


### PR DESCRIPTION
## Summary

- add a 32 KiB 64-bit AXI BRAM at 0x37f00000 for extLLC boot software
- support byte writes through an AXI BRAM controller
- use the extllc prefix for the BRAM controller and memory instances
- keep the new memory outside the JTAG flash address space

## Validation

- sourced AXI_bridge.tcl and validated the block design with Vivado 2024.2
- confirmed a 4096 x 64 single-port BRAM
- confirmed the CPU 0x37f00000/0x8000 mapping and unchanged JTAG flash-only mapping