### PR TITLE
fix(fpga_diff): keep External LLC RTL on AXI path

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -2,6 +2,7 @@ ENV_SCRIPTS_HOME ?= $(CURDIR)
 
 CORE_DIR ?=
 CHI_DIR ?=
+RTL_INCLUDE ?=
 FPGA_BIT_HOME ?=
 WORKLOAD ?=
 AXI_WIDTH ?= 64
@@ -23,7 +24,7 @@ PRJ_NAME = fpga_$(CPU)$(if $(strip $(SUFFIX)),-$(strip $(SUFFIX)),)
 PRJ_DIR ?= $(ENV_SCRIPTS_HOME)/$(PRJ_NAME)
 PRJ ?= $(PRJ_DIR)/$(PRJ_NAME).xpr
 
-.PHONY: bitstream vivado dump_ila write_jtag_flash
+.PHONY: bitstream vivado dump_ila write_jtag_flash update_core_flist
 
 # Get Vivado version
 VIVADO_VERSION := $(shell vivado -version 2>/dev/null | head -1 | grep -o '[0-9]\{4\}\.[0-9]' || echo "unknown")
@@ -41,13 +42,34 @@ bitstream:
 
 # Update file list for core RTL files
 update_core_flist:
-	rm -rf $(CORE_DIR)/rtl/verification
-	find "$(CORE_DIR)" -type f \( -name "*.v" -o -name "*.sv" -o -name "*.svh" \) -printf '%p\n' | \
-	awk -f ./core_flist.awk > ./src/tcl/cpu_files.tcl
+	@set -e; \
+	if [ -z "$(CORE_DIR)" ]; then echo "ERROR: CORE_DIR is required" >&2; exit 1; fi; \
+	tmp=$$(mktemp); \
+	rtl_tmp=$$(mktemp); \
+	trap 'rm -f "$$tmp" "$$rtl_tmp"' 0; \
+	rm -rf "$(CORE_DIR)/rtl/verification"; \
+	find "$(CORE_DIR)" -type f \( -name "*.v" -o -name "*.sv" -o -name "*.svh" -o -name "*.vh" \) -printf '%p\n' > "$$tmp"; \
+	has_rtl_include=0; \
+	for path in $(RTL_INCLUDE); do \
+	  has_rtl_include=1; \
+	  if [ -d "$$path" ]; then \
+	    find "$$path" -type f \( -name "*.v" -o -name "*.sv" -o -name "*.svh" -o -name "*.vh" \) -printf '%p\n' >> "$$rtl_tmp"; \
+	  elif [ -f "$$path" ]; then \
+	    case "$$path" in \
+	      *.v|*.sv|*.svh|*.vh) printf '%s\n' "$$path" >> "$$rtl_tmp" ;; \
+	      *) echo "ERROR: unsupported RTL_INCLUDE file: $$path" >&2; exit 1 ;; \
+	    esac; \
+	  else \
+	    echo "ERROR: RTL_INCLUDE path not found: $$path" >&2; exit 1; \
+	  fi; \
+	done; \
+	awk -v var=cpu_files -v detect_simtop_dma=1 -f ./core_flist.awk "$$tmp" > ./src/tcl/cpu_files.tcl; \
+	awk -v var=rtl_include_files -f ./core_flist.awk "$$rtl_tmp" >> ./src/tcl/cpu_files.tcl; \
+	printf 'set cpu_files_has_rtl_include %s\n' "$$has_rtl_include" >> ./src/tcl/cpu_files.tcl
 
 # Update file list for CHI interface files
 update_chi_flist:
-	find "$(CHI_DIR)" -type f \( -name "*.v" -o -name "*.sv" -o -name "*.svh" \) -printf '%p\n' | \
+	find "$(CHI_DIR)" -type f \( -name "*.v" -o -name "*.sv" -o -name "*.svh" -o -name "*.vh" \) -printf '%p\n' | \
 	awk -f ./chi_flist.awk > ./src/tcl/chi_files.tcl;
 
 # Launch Vivado with FPGA project configuration
@@ -107,5 +129,5 @@ all:
 ifneq ($(strip $(CHI_DIR)),)
 	$(MAKE) update_chi_flist CHI_DIR="$(CHI_DIR)"
 endif
-	$(MAKE) update_core_flist CORE_DIR=$(CORE_DIR)
+	$(MAKE) update_core_flist CORE_DIR="$(CORE_DIR)" RTL_INCLUDE="$(RTL_INCLUDE)"
 	$(MAKE) vivado CPU=$(CPU) SUFFIX="$(SUFFIX)"

--- a/fpga_diff/core_flist.awk
+++ b/fpga_diff/core_flist.awk
@@ -1,7 +1,39 @@
-BEGIN{printf "set cpu_files [list \\\n"}
+function simtop_has_dma(path, line, in_simtop) {
+    while ((getline line < path) > 0) {
+        if (!in_simtop && line ~ /^[[:space:]]*module[[:space:]]+/) {
+            if (line !~ /^[[:space:]]*module[[:space:]]+SimTop([[:space:]#(]|$)/) {
+                close(path)
+                return 0
+            }
+            in_simtop = 1
+        }
+        if (in_simtop && line ~ /dma_awready/) {
+            close(path)
+            return 1
+        }
+        if (in_simtop && line ~ /^[[:space:]]*\);/) {
+            break
+        }
+    }
+    close(path)
+    return 0
+}
+
+BEGIN{
+    if (var == "") var = "cpu_files"
+    printf "set %s [list \\\n", var
+}
 {
+    if (detect_simtop_dma && !has_simtop_dma && simtop_has_dma($0)) {
+        has_simtop_dma = 1
+    }
     printf " [file normalize \""
     printf $0
     printf "\" ]\\\n"
 }
-END{printf "]\n"}
+END{
+    printf "]\n"
+    if (detect_simtop_dma) {
+        printf "set cpu_files_has_dma %d\n", has_simtop_dma
+    }
+}

--- a/fpga_diff/src/rtl/common/core_def_xdma.sv
+++ b/fpga_diff/src/rtl/common/core_def_xdma.sv
@@ -5,10 +5,10 @@
 `define XDMA_PCIE_LANES 4
 `endif
 
-`ifdef CONFIG_USE_XSCORE_CHI
+`ifdef CONFIG_FPGA_XSCORE_CHI
 `include "kconfig.svh"
 `include "chi_icn_defines.svh"
-`elsif CONFIG_USE_XSCORE_AXI
+`elsif CONFIG_FPGA_XSCORE_AXI
 `ifndef CONFIG_RANK_WIDTH
 `define CONFIG_RANK_WIDTH 1
 `endif
@@ -1121,7 +1121,7 @@ assign cfg_pcie1_s2m_rvalid = 1;
     wire [31:0]                   xstile_imsic_rdata          [`CONFIG_XSCORE_NR-1:0];
     wire [1:0]                    xstile_imsic_rresp          [`CONFIG_XSCORE_NR-1:0];
 `endif /* CONFIG_USE_IMSIC */
-`ifdef CONFIG_USE_XSCORE_CHI
+`ifdef CONFIG_FPGA_XSCORE_CHI
     /* XSTile RN-F */
     wire                          xstile_chi_syscoreq         [`CONFIG_XSCORE_NR-1:0];
     wire                          xstile_chi_syscoack         [`CONFIG_XSCORE_NR-1:0];
@@ -1453,7 +1453,7 @@ jtag_ddr_subsys_wrapper U_JTAG_DDR_SUBSYS(
     // AXI INTERFACE CLK
     .SOC_CLK                (inter_soc_clk),
 
-`ifdef CONFIG_USE_XSCORE_AXI
+`ifdef CONFIG_FPGA_XSCORE_AXI
     .SOC_M_AXI_awid         (cpu2ddr_m2s_awid_mix          ),
     .SOC_M_AXI_awaddr       (cpu2ddr_m2s_awaddr_mix        ),
     .SOC_M_AXI_awlen        (cpu2ddr_m2s_awlen             ),
@@ -1491,7 +1491,7 @@ jtag_ddr_subsys_wrapper U_JTAG_DDR_SUBSYS(
     .SOC_M_AXI_rlast        (cpu2ddr_s2m_rlast             ),
     .SOC_M_AXI_rvalid       (cpu2ddr_s2m_rvalid            ),
     .SOC_M_AXI_rready       (cpu2ddr_m2s_rready            ),
-`elsif CONFIG_USE_XSCORE_CHI
+`elsif CONFIG_FPGA_XSCORE_CHI
     .SOC_M_AXI_awid         (cmn2ddr_awid   ),
     .SOC_M_AXI_awaddr       (cmn2ddr_awaddr_mix),
     .SOC_M_AXI_awlen        (cmn2ddr_awlen  ),
@@ -1531,7 +1531,7 @@ jtag_ddr_subsys_wrapper U_JTAG_DDR_SUBSYS(
     .SOC_M_AXI_rlast        (cmn2ddr_rlast  ),
     .SOC_M_AXI_rvalid       (cmn2ddr_rvalid ),
     .SOC_M_AXI_rready       (cmn2ddr_rready ),
-`endif // CONFIG_USE_XSCORE_AXI
+`endif // CONFIG_FPGA_XSCORE_AXI
 `ifdef CONFIG_HAVE_DDRC_MCU_PERI_AXI
     /* ext peri AXI */
     .M_AXI_DP_araddr        (mcu_axi_dp_araddr  ),
@@ -1575,7 +1575,7 @@ jtag_ddr_subsys_wrapper U_JTAG_DDR_SUBSYS(
     .calib_complete         (init_calib_complete)
 );
 
-`ifdef CONFIG_USE_XSCORE_CHI
+`ifdef CONFIG_FPGA_XSCORE_CHI
 xs_sys_icn u_icn(
     .clock(noc_clk),
     .rstn(sys_rstn),
@@ -1590,7 +1590,7 @@ xs_sys_icn u_icn(
     .io_clintTime_bits  (io_clintTime_bits),
     .io_irq_sources     ({cpu_int_mix[63:15],pcie_int,cpu_int_mix[12:0]}),
     .plic_int           (plic_int),
-`ifdef CONFIG_USE_XSCORE_CHI
+`ifdef CONFIG_FPGA_XSCORE_CHI
     .debug_module_hart              (debug_module_hart),
     .io_hartIsInReset               (io_hartIsInReset),
     .debug_module_ndreset           (debug_module_ndreset),
@@ -1599,7 +1599,7 @@ xs_sys_icn u_icn(
     .io_systemjtag_jtag_TDI         (io_systemjtag_jtag_TDI),
     .io_systemjtag_jtag_TDO_data    (io_systemjtag_jtag_TDO_data),
     .io_systemjtag_jtag_TDO_driven  (io_systemjtag_jtag_TDO_driven),
-`endif /* CONFIG_USE_XSCORE_CHI */
+`endif /* CONFIG_FPGA_XSCORE_CHI */
 `endif /* CONFIG_HAVE_ONCHIP_PERI */
 
 `ifdef CONFIG_ICN_CFG_PORT
@@ -1641,7 +1641,7 @@ xs_sys_icn u_icn(
     .icn_cfg_wvalid  (mcu_axi_dp_wvalid ),
 `endif /* CONFIG_ICN_CFG_PORT */
 
-`ifdef CONFIG_USE_XSCORE_AXI
+`ifdef CONFIG_FPGA_XSCORE_AXI
     /* AXI: with mem/mmio ports */
     .core_axi_awready         (cpu2ddr_s2m_awready),
     .core_axi_awvalid         (cpu2ddr_m2s_awvalid),
@@ -1720,7 +1720,7 @@ xs_sys_icn u_icn(
     .core_mmio_wstrb   (cpu2cfg_m2s_wstrb  ),
     .core_mmio_wvalid  (cpu2cfg_m2s_wvalid ),
 
-`elsif CONFIG_USE_XSCORE_CHI
+`elsif CONFIG_FPGA_XSCORE_CHI
     /* CHI */
     .core_chi_syscoreq        (xstile_chi_syscoreq ),
     .core_chi_syscoack        (xstile_chi_syscoack ),
@@ -2050,7 +2050,7 @@ SimTop_wrapper U_CPU_TOP(
     .io_imsic_rdata                 (xstile_imsic_rdata),
     .io_imsic_rresp                 (xstile_imsic_rresp),
 `endif /* CONFIG_USE_IMSIC */
-`ifdef CONFIG_USE_XSCORE_AXI
+`ifdef CONFIG_FPGA_XSCORE_AXI
     .io_systemjtag_jtag_TCK         (io_systemjtag_jtag_TCK),
     .io_systemjtag_jtag_TMS         (io_systemjtag_jtag_TMS),
     .io_systemjtag_jtag_TDI         (io_systemjtag_jtag_TDI),
@@ -2175,7 +2175,7 @@ SimTop_wrapper U_CPU_TOP(
     .mem_core_rlast                 (cpu2ddr_s2m_rlast),
 
     .io_extIntrs                    (cpu_int_mix)
-`elsif CONFIG_USE_XSCORE_CHI
+`elsif CONFIG_FPGA_XSCORE_CHI
     .noc_clk                        (noc_clk ),
     .noc_rstn                       (cpu_rstn_io),
     .clint_int_0                    (clint_int_0[`CONFIG_XSCORE_NR-1:0]),

--- a/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
+++ b/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
@@ -1,7 +1,7 @@
 `include "DifftestMacros.svh"
 `include "sys_define.vh"
 
-`ifdef CONFIG_USE_XSCORE_CHI
+`ifdef CONFIG_FPGA_XSCORE_CHI
 `include "kconfig.svh"
 `include "chi_icn_defines.svh"
 `endif
@@ -21,7 +21,7 @@ module SimTop_wrapper(
   input  [15:0]   soc_to_cpu,   // none
   output [15:0]   cpu_to_soc,   //none
 
-`ifdef CONFIG_USE_XSCORE_AXI
+`ifdef CONFIG_FPGA_XSCORE_AXI
   input  [63:0]   io_extIntrs,   // come from IPs, Max : 600MHz
 
   input  [15:0]   io_sram_config,  //apb clk : 100MHz
@@ -151,7 +151,7 @@ module SimTop_wrapper(
   (*mark_debug="true"*) input  [1:0]    mem_core_rresp,
   (*mark_debug="true"*) input           mem_core_rlast,
 
-`elsif CONFIG_USE_XSCORE_CHI
+`elsif CONFIG_FPGA_XSCORE_CHI
   input                                 noc_clk,
   input                                 noc_rstn,
   input                                 clint_int_0[`CONFIG_XSCORE_NR-1:0],
@@ -270,7 +270,7 @@ module SimTop_wrapper(
   input           difftest_cfg_axilite_rready
 );
 
-`ifdef CONFIG_USE_XSCORE_AXI
+`ifdef CONFIG_FPGA_XSCORE_AXI
   wire          cpu_clock       ;
   wire          cpu_global_reset;
   wire          global_reset_sync;
@@ -532,7 +532,7 @@ SimTop  u_XSTop(
   .io_traceCoreInterface_0_toEncoder_iretire  (trace_iretire),
   .io_traceCoreInterface_0_toEncoder_ilastsize(trace_ilastsize)
 );
-`elsif CONFIG_USE_XSCORE_CHI
+`elsif CONFIG_FPGA_XSCORE_CHI
 
   wire xstile_cpu_reset;
   XSTileResetGen reset_sync_resetSync_cpu (

--- a/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
+++ b/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
@@ -302,6 +302,20 @@ wire [11:0]  trace_itype;
 wire [20:0]  trace_iretire;
 wire [2:0]   trace_ilastsize;
 
+`ifndef CONFIG_SIMTOP_HAS_DMA
+assign dma_core_awready = 1'b0;
+assign dma_core_wready  = 1'b0;
+assign dma_core_bvalid  = 1'b0;
+assign dma_core_bid     = '0;
+assign dma_core_bresp   = '0;
+assign dma_core_arready = 1'b0;
+assign dma_core_rvalid  = 1'b0;
+assign dma_core_rid     = '0;
+assign dma_core_rdata   = '0;
+assign dma_core_rresp   = '0;
+assign dma_core_rlast   = 1'b0;
+`endif
+
 SimTop  u_XSTop(
   .clock                         (inter_soc_clk),
   .reset                         (~sys_rstn_i),
@@ -346,6 +360,7 @@ SimTop  u_XSTop(
   .peripheral_rdata              (peri_rdata    ),
   .peripheral_rresp              (peri_rresp    ),
   .peripheral_rlast              (peri_rlast    ),
+`ifdef CONFIG_SIMTOP_HAS_DMA
   .dma_awready                   (dma_core_awready ),
   .dma_awvalid                   (dma_core_awvalid ),
   .dma_awid                      (dma_core_awid    ),
@@ -383,7 +398,7 @@ SimTop  u_XSTop(
   .dma_rdata                     (dma_core_rdata   ),
   .dma_rresp                     (dma_core_rresp   ),
   .dma_rlast                     (dma_core_rlast   ),
-
+`endif
   .io_systemjtag_jtag_TCK          (io_systemjtag_jtag_TCK),
   .io_systemjtag_jtag_TMS          (io_systemjtag_jtag_TMS),
   .io_systemjtag_jtag_TDI          (io_systemjtag_jtag_TDI),

--- a/fpga_diff/src/tcl/common/AXI_bridge.tcl
+++ b/fpga_diff/src/tcl/common/AXI_bridge.tcl
@@ -122,12 +122,14 @@ set bCheckIPsPassed 1
 ##################################################################
 set bCheckIPs 1
 if { $bCheckIPs == 1 } {
-   set list_check_ips "\ 
-xilinx.com:ip:axi_apb_bridge:3.0\
-xilinx.com:ip:axi_uart16550:2.0\
-xilinx.com:ip:jtag_axi:1.2\
-xilinx.com:ip:xlconstant:1.1\
-"
+   set list_check_ips {
+      xilinx.com:ip:axi_apb_bridge:3.0
+      xilinx.com:ip:axi_bram_ctrl:4.1
+      xilinx.com:ip:axi_uart16550:2.0
+      xilinx.com:ip:blk_mem_gen:8.4
+      xilinx.com:ip:jtag_axi:1.2
+      xilinx.com:ip:xlconstant:1.1
+   }
 
    set list_ips_missing ""
    common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
@@ -265,9 +267,29 @@ proc create_root_design { parentCell } {
   # Create instance: axi_interconnect_0, and set properties
   set axi_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_interconnect_0 ]
   set_property -dict [ list \
-   CONFIG.NUM_MI {3} \
+   CONFIG.NUM_MI {4} \
    CONFIG.NUM_SI {2} \
  ] $axi_interconnect_0
+
+  # Create instance: external_llc_bram_ctrl, and set properties
+  set external_llc_bram_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl:4.1 external_llc_bram_ctrl ]
+  set_property -dict [ list \
+   CONFIG.DATA_WIDTH {64} \
+   CONFIG.ECC_TYPE {0} \
+   CONFIG.SINGLE_PORT_BRAM {1} \
+ ] $external_llc_bram_ctrl
+
+  # Create instance: external_llc_bram, and set properties
+  set external_llc_bram [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 external_llc_bram ]
+  set_property -dict [ list \
+   CONFIG.Byte_Size {8} \
+   CONFIG.Load_Init_File {false} \
+   CONFIG.Memory_Type {Single_Port_RAM} \
+   CONFIG.Read_Width_A {64} \
+   CONFIG.Use_Byte_Write_Enable {true} \
+   CONFIG.Write_Depth_A {4096} \
+   CONFIG.Write_Width_A {64} \
+ ] $external_llc_bram
 
   # Create instance: axi_uart16550_0, and set properties
   set axi_uart16550_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_uart16550:2.0 axi_uart16550_0 ]
@@ -297,12 +319,14 @@ proc create_root_design { parentCell } {
   connect_bd_intf_net -intf_net axi_interconnect_0_M01_AXI [get_bd_intf_pins axi_interconnect_0/M01_AXI] [get_bd_intf_pins axi_uart16550_0/S_AXI]
   set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets axi_interconnect_0_M01_AXI]
   connect_bd_intf_net -intf_net axi_interconnect_0_M02_AXI [get_bd_intf_ports rom_axi] [get_bd_intf_pins axi_interconnect_0/M02_AXI]
+  connect_bd_intf_net -intf_net axi_interconnect_0_M03_AXI [get_bd_intf_pins axi_interconnect_0/M03_AXI] [get_bd_intf_pins external_llc_bram_ctrl/S_AXI]
+  connect_bd_intf_net -intf_net external_llc_bram_ctrl_BRAM_PORTA [get_bd_intf_pins external_llc_bram_ctrl/BRAM_PORTA] [get_bd_intf_pins external_llc_bram/BRAM_PORTA]
   connect_bd_intf_net -intf_net jtag_axi_flash_M_AXI [get_bd_intf_pins axi_interconnect_0/S01_AXI] [get_bd_intf_pins jtag_axi_flash/M_AXI]
   connect_bd_intf_net -intf_net axi_uart16550_0_UART [get_bd_intf_ports UART_0] [get_bd_intf_pins axi_uart16550_0/UART]
 
   # Create port connections
-  connect_bd_net -net ACLK_0_1 [get_bd_ports ACLK] [get_bd_pins axi_apb_bridge_0/s_axi_aclk] [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_interconnect_0/M00_ACLK] [get_bd_pins axi_interconnect_0/M01_ACLK] [get_bd_pins axi_interconnect_0/M02_ACLK] [get_bd_pins axi_interconnect_0/S01_ACLK] [get_bd_pins axi_uart16550_0/s_axi_aclk] [get_bd_pins jtag_axi_flash/aclk]
-  connect_bd_net -net ARESETN_0_1 [get_bd_ports ARESETN] [get_bd_pins axi_apb_bridge_0/s_axi_aresetn] [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_interconnect_0/M00_ARESETN] [get_bd_pins axi_interconnect_0/M01_ARESETN] [get_bd_pins axi_interconnect_0/M02_ARESETN] [get_bd_pins axi_interconnect_0/S00_ARESETN] [get_bd_pins axi_interconnect_0/S01_ARESETN] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins jtag_axi_flash/aresetn]
+  connect_bd_net -net ACLK_0_1 [get_bd_ports ACLK] [get_bd_pins axi_apb_bridge_0/s_axi_aclk] [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_interconnect_0/M00_ACLK] [get_bd_pins axi_interconnect_0/M01_ACLK] [get_bd_pins axi_interconnect_0/M02_ACLK] [get_bd_pins axi_interconnect_0/M03_ACLK] [get_bd_pins axi_interconnect_0/S01_ACLK] [get_bd_pins axi_uart16550_0/s_axi_aclk] [get_bd_pins external_llc_bram_ctrl/s_axi_aclk] [get_bd_pins jtag_axi_flash/aclk]
+  connect_bd_net -net ARESETN_0_1 [get_bd_ports ARESETN] [get_bd_pins axi_apb_bridge_0/s_axi_aresetn] [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_interconnect_0/M00_ARESETN] [get_bd_pins axi_interconnect_0/M01_ARESETN] [get_bd_pins axi_interconnect_0/M02_ARESETN] [get_bd_pins axi_interconnect_0/M03_ARESETN] [get_bd_pins axi_interconnect_0/S00_ARESETN] [get_bd_pins axi_interconnect_0/S01_ARESETN] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins external_llc_bram_ctrl/s_axi_aresetn] [get_bd_pins jtag_axi_flash/aresetn]
   connect_bd_net -net SYS_INTER_CLK_1 [get_bd_ports SYS_INTER_CLK] [get_bd_pins axi_interconnect_0/S00_ACLK]
   connect_bd_net -net axi_uart16550_0_ip2intc_irpt [get_bd_ports uart0_intc] [get_bd_pins axi_uart16550_0/ip2intc_irpt]
   connect_bd_net -net xlconstant_0_dout [get_bd_pins axi_uart16550_0/freeze] [get_bd_pins xlconstant_0/dout]
@@ -311,9 +335,11 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0x31200000 -range 0x00010000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs SYS_CFG_APB/Reg] -force
   assign_bd_address -offset 0x310B0000 -range 0x00010000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg] -force
   assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs rom_axi/Reg] -force
+  assign_bd_address -offset 0x37F00000 -range 0x00008000 -target_address_space [get_bd_addr_spaces S00_AXI] [get_bd_addr_segs external_llc_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x10000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs rom_axi/Reg] -force
   exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs SYS_CFG_APB/Reg]
   exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces jtag_axi_flash/Data] [get_bd_addr_segs external_llc_bram_ctrl/S_AXI/Mem0]
 
 
   # Restore current instance

--- a/fpga_diff/src/tcl/common/header_files.tcl
+++ b/fpga_diff/src/tcl/common/header_files.tcl
@@ -1,0 +1,91 @@
+########################################################################
+# Mark files that are parsed through include as Verilog headers.
+########################################################################
+
+proc fpga_append_unique {var_name value} {
+  upvar 1 $var_name values
+  if {[lsearch -exact $values $value] < 0} {
+    lappend values $value
+  }
+}
+
+proc fpga_included_source_files {files include_dirs} {
+  array set known_files {}
+  array set files_by_tail {}
+  set search_dirs {}
+
+  foreach dir $include_dirs {
+    if {[file isdirectory $dir]} {
+      fpga_append_unique search_dirs [file normalize $dir]
+    }
+  }
+  foreach file $files {
+    if {![file isfile $file]} {
+      continue
+    }
+    set path [file normalize $file]
+    set known_files($path) 1
+    lappend files_by_tail([file tail $path]) $path
+    fpga_append_unique search_dirs [file dirname $path]
+  }
+
+  array set included_files {}
+  foreach file [array names known_files] {
+    set in [open $file r]
+    while {[gets $in line] >= 0} {
+      if {![regexp {^[[:space:]]*\x60include[[:space:]]+["<]([^">]+)[">]} $line -> include_path]} {
+        continue
+      }
+
+      if {[file pathtype $include_path] eq "absolute"} {
+        set candidates [list [file normalize $include_path]]
+      } else {
+        set candidates [list [file normalize [file join [file dirname $file] $include_path]]]
+        foreach dir $search_dirs {
+          lappend candidates [file normalize [file join $dir $include_path]]
+        }
+      }
+
+      set included_path ""
+      foreach candidate $candidates {
+        if {[info exists known_files($candidate)]} {
+          set included_path $candidate
+          break
+        }
+      }
+      if {$included_path eq "" && [info exists files_by_tail([file tail $include_path])]} {
+        set same_tail $files_by_tail([file tail $include_path])
+        if {[llength $same_tail] == 1} {
+          set included_path [lindex $same_tail 0]
+        }
+      }
+      if {$included_path ne ""} {
+        set included_files($included_path) 1
+      }
+    }
+    close $in
+  }
+  return [array names included_files]
+}
+
+proc fpga_set_header_file_types {files include_dirs} {
+  array set header_files {}
+  foreach file [fpga_included_source_files $files $include_dirs] {
+    set header_files($file) 1
+  }
+
+  foreach file $files {
+    set objects [get_files -quiet $file]
+    if {[llength $objects] == 0} {
+      continue
+    }
+
+    set extension [string tolower [file extension $file]]
+    set path [file normalize $file]
+    if {$extension in {.svh .vh} || [info exists header_files($path)]} {
+      set_property -name file_type -value {Verilog Header} -objects $objects
+    } elseif {$extension eq ".v"} {
+      set_property -name file_type -value {SystemVerilog} -objects $objects
+    }
+  }
+}

--- a/fpga_diff/src/tcl/common/xs_uart.tcl
+++ b/fpga_diff/src/tcl/common/xs_uart.tcl
@@ -228,19 +228,22 @@ set_property -name "include_dirs" -value "$include_dirs" -objects $obj
 set_property -name "top" -value "fpga_top_debug" -objects $obj
 set_property -name "top_auto_set" -value "0" -objects $obj
 
-# RTL_INCLUDE may add auxiliary RTL to an AXI SimTop_wrapper. Only the
-# legacy CHI_DIR flow changes the generated top-level interface to CHI.
+# External RTL may define CONFIG_USE_XSCORE_CHI internally. Keep the
+# platform wrapper selection separate from those source-local macros.
 if { [llength $chi_files] > 0 } {
     lappend defines "MSI_MODE"
     lappend defines "CONFIG_USE_XSCORE_CHI"
-    puts "INFO: Defined MSI_MODE and CONFIG_USE_XSCORE_CHI for CHI RTL"
+    lappend defines "CONFIG_FPGA_XSCORE_CHI"
+    puts "INFO: Defined MSI_MODE and CONFIG_FPGA_XSCORE_CHI for CHI RTL"
 } elseif { $cpu_files_has_rtl_include } {
     lappend defines "MSI_MODE"
     lappend defines "CONFIG_USE_XSCORE_AXI"
-    puts "INFO: Defined MSI_MODE for RTL_INCLUDE without changing SimTop_wrapper to CHI"
+    lappend defines "CONFIG_FPGA_XSCORE_AXI"
+    puts "INFO: Defined MSI_MODE and CONFIG_FPGA_XSCORE_AXI for RTL_INCLUDE"
 } else {
     puts "INFO: MSI_MODE macro not defined as external RTL files are not present"
     lappend defines "CONFIG_USE_XSCORE_AXI"
+    lappend defines "CONFIG_FPGA_XSCORE_AXI"
 }
 
 if {$cpu_files_has_dma} {

--- a/fpga_diff/src/tcl/common/xs_uart.tcl
+++ b/fpga_diff/src/tcl/common/xs_uart.tcl
@@ -132,6 +132,7 @@ source "$tcl_dir/common/rtl_files.tcl"
 source "$tcl_dir/common/constraints.tcl"
 source "$tcl_dir/common/defines.tcl"
 source "$tcl_dir/common/include_dirs.tcl"
+source "$tcl_dir/common/header_files.tcl"
 
 set cpu_hit "no"
 foreach cpu_candidate $cpu_candidates {
@@ -139,6 +140,9 @@ foreach cpu_candidate $cpu_candidates {
     set cpu_hit "yes"
   }
 }
+set cpu_files_has_rtl_include 0
+set cpu_files_has_dma 1
+set rtl_include_files [list]
 if {[string equal $cpu_hit "no"]} {
   puts "ERROR: Unknown cpu target '$cpu' specified by '--cpu', please select one from {$cpu_candidates}.\n"
   return 1
@@ -154,7 +158,19 @@ if { [file exists "$tcl_dir/chi_files.tcl"] } {
   source "$tcl_dir/chi_files.tcl"
 }
 
-set xs_files [list {*}$cpu_files {*}$ip_files {*}$rtl_files {*}$chi_files]
+if {$cpu_files_has_rtl_include} {
+  foreach rtl_file $rtl_include_files {
+    set rtl_include_dir [file normalize [file dirname $rtl_file]]
+    if {[lsearch -exact $include_dirs $rtl_include_dir] < 0} {
+      lappend include_dirs $rtl_include_dir
+    }
+  }
+}
+
+# Keep auxiliary RTL after the local FPGA wrapper.  Some auxiliary headers
+# define interconnect protocol macros, while the local wrapper must retain its
+# AXI top-level elaboration.
+set xs_files [list {*}$cpu_files {*}$ip_files {*}$rtl_files {*}$chi_files {*}$rtl_include_files]
 
 # Check for paths and files needed for project creation
 set validate_required 1
@@ -204,36 +220,7 @@ set obj [get_filesets sources_1]
 set_property SOURCE_SET sources_1 [get_filesets sim_1]
 add_files -norecurse -fileset $obj $xs_files
 
-# Set file type to "SystemVerilog" for all .v files as base type
-# This should be done before setting specific files to "Verilog Header"
-foreach file $xs_files {
-  set file_extension [file extension $file]
-  if { [string equal -nocase $file_extension ".v"] } {
-    set_property -name file_type -value {SystemVerilog} -objects [get_files $file]
-  }
-}
-
-# Set file type to "Verilog Header" for files matching specific patterns in CHI files
-foreach chi_file $chi_files {
-  set filename [file tail $chi_file]
-  if { [string match "*_define*" $filename] || [string match "*_structs*" $filename] ||
-       [string match "*_params*" $filename] || [string match "*rnid_inc*" $filename] ||
-       [string match "*hns_inc*" $filename] || [string match "*hni_inc*" $filename] ||
-       [string match "*_pkg*" $filename] || [string match "*_function*" $filename] ||
-       [string match "*_localparam*" $filename] || [string match "*axi_lite_slave*" $filename]} {
-      puts "INFO: Setting $filename file_type to 'Verilog Header'"
-      set_property -name file_type -value {Verilog Header} -objects [get_files $chi_file]
-    }
-}
-
-# If DifftestMacros.v exists, set its file_type to 'Verilog Header' to avoid being treated as a top/regular synthesizable source
-set difftest_hdr [get_files -quiet *DifftestMacros.v]
-if {[llength $difftest_hdr] > 0} {
-  puts "INFO: Setting DifftestMacros.v file_type to 'Verilog Header'"
-  set_property -name file_type -value {Verilog Header} -objects $difftest_hdr
-} else {
-  puts "INFO: DifftestMacros.v not found at add phase; skip header type setting"
-}
+fpga_set_header_file_types $xs_files $include_dirs
 
 # Set 'sources_1' fileset properties
 set obj [get_filesets sources_1]
@@ -241,14 +228,26 @@ set_property -name "include_dirs" -value "$include_dirs" -objects $obj
 set_property -name "top" -value "fpga_top_debug" -objects $obj
 set_property -name "top_auto_set" -value "0" -objects $obj
 
-# Define MSI_MODE macro only if CHI files exist
+# RTL_INCLUDE may add auxiliary RTL to an AXI SimTop_wrapper. Only the
+# legacy CHI_DIR flow changes the generated top-level interface to CHI.
 if { [llength $chi_files] > 0 } {
     lappend defines "MSI_MODE"
     lappend defines "CONFIG_USE_XSCORE_CHI"
-    puts "INFO: Defined MSI_MODE macro as CHI files are present"
-} else {
-    puts "INFO: MSI_MODE macro not defined as CHI files are not present"
+    puts "INFO: Defined MSI_MODE and CONFIG_USE_XSCORE_CHI for CHI RTL"
+} elseif { $cpu_files_has_rtl_include } {
+    lappend defines "MSI_MODE"
     lappend defines "CONFIG_USE_XSCORE_AXI"
+    puts "INFO: Defined MSI_MODE for RTL_INCLUDE without changing SimTop_wrapper to CHI"
+} else {
+    puts "INFO: MSI_MODE macro not defined as external RTL files are not present"
+    lappend defines "CONFIG_USE_XSCORE_AXI"
+}
+
+if {$cpu_files_has_dma} {
+    lappend defines "CONFIG_SIMTOP_HAS_DMA"
+    puts "INFO: SimTop DMA ports detected"
+} else {
+    puts "INFO: SimTop DMA ports not present; wrapper DMA is tied off"
 }
 
 set xdma_pcie_lanes 4

--- a/fpga_diff/tools/jtag_write_flash.tcl
+++ b/fpga_diff/tools/jtag_write_flash.tcl
@@ -162,7 +162,8 @@ proc write_flash {bytes hw_axi base_addr max_len} {
     }
 
     set data_hex ""
-    for {set i 0} {$i < $chunk_len} {incr i} {
+    # Vivado maps the rightmost data beat to the lowest INCR address.
+    for {set i [expr {$chunk_len - 1}]} {$i >= 0} {incr i -1} {
       append data_hex [word_hex $bytes [expr {($word_index + $i) * $beat_bytes}]]
     }
 


### PR DESCRIPTION
## Summary

- Select the FPGA wrapper protocol from the build path.
- Keep External LLC RTL_INCLUDE builds on AXI when imported headers define CHI internally.

## Validation

- Restarted r7 Vivado synthesis with the explicit AXI wrapper mode.