### PR TITLE
feat(fpga_diff): bridge remote UART for fpga-host

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -14,6 +14,10 @@ XDMA_LINK_WIDTH ?= X4
 VIVADO_JOBS ?=
 DDR_RANK_WIDTH ?= 2
 export ENABLE_ILA ILA_DEPTH XDMA_LINK_WIDTH VIVADO_JOBS DDR_RANK_WIDTH NO_DIFF
+REMOTE ?=
+REMOTE_UART_PORT ?= /dev/ttyUSB0
+REMOTE_UART_BAUD ?= 115200
+FPGA_UART_PORT ?= /tmp/fpga-remote-uart
 # Supported CPU parameters:
 #   kmh
 #   nutshell
@@ -30,7 +34,26 @@ PRJ_DIR ?= $(ENV_SCRIPTS_HOME)/$(PRJ_NAME)
 PRJ ?= $(PRJ_DIR)/$(PRJ_NAME).xpr
 
 .PHONY: bitstream vivado dump_ila update_core_flist \
-	write_bitstream halt_soc write_jtag_ddr write_jtag_flash reset_cpu
+	write_bitstream halt_soc write_jtag_ddr write_jtag_flash reset_cpu \
+	bind_uart uart_env
+
+# Print the environment assignment consumed by fpga-host.
+uart_env:
+	@printf 'export FPGA_UART_PORT=%s\n' '$(FPGA_UART_PORT)'
+
+# Bridge REMOTE_UART_PORT through SSH to a local PTY for fpga-host.
+# Start an interactive shell with FPGA_UART_PORT exported after the bridge starts.
+bind_uart:
+	@test -n "$(REMOTE)" || { echo "REMOTE is required (for example: REMOTE=fpga)" >&2; exit 2; }
+	@command -v socat >/dev/null || { echo "socat is required on the local host" >&2; exit 2; }
+	@set -e; \
+	socat -d -d pty,link="$(FPGA_UART_PORT)",rawer,echo=0,waitslave \
+		EXEC:"ssh -T $(REMOTE) 'exec socat - $(REMOTE_UART_PORT),rawer,b$(REMOTE_UART_BAUD)'",nofork & \
+	bridge_pid=$$!; \
+	trap 'kill $$bridge_pid 2>/dev/null || true; wait $$bridge_pid 2>/dev/null || true' 0 INT TERM; \
+	export FPGA_UART_PORT="$(FPGA_UART_PORT)"; \
+	printf 'FPGA_UART_PORT=%s\n' "$$FPGA_UART_PORT"; \
+	$(SHELL) -i
 
 # Get Vivado version
 VIVADO_VERSION := $(shell vivado -version 2>/dev/null | head -1 | grep -o '[0-9]\{4\}\.[0-9]' || echo "unknown")

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -48,6 +48,27 @@ FPGA_DDR_LOAD_CMD="bash -lc ' \
 ./fpga-host --diff <nemu> -i <workload>.bin
 ```
 
+Remote UART for fpga-host
+=========================
+
+When fpga-host runs on a machine other than the FPGA USB-UART host, bridge
+the remote UART to a local pseudo-terminal. Install socat on both hosts, then
+start the bridge:
+
+    make bind_uart REMOTE=<user@fpga-host>
+
+The target bridges remote /dev/ttyUSB0 at 115200 baud to
+/tmp/fpga-remote-uart locally, exports FPGA_UART_PORT, and starts an
+interactive shell. Run fpga-host in that shell; leaving it stops the bridge.
+Override REMOTE_UART_PORT, REMOTE_UART_BAUD, or FPGA_UART_PORT when needed.
+For a scripted invocation, obtain the same environment assignment with:
+
+    eval "$(make -s uart_env REMOTE=<user@fpga-host>)"
+
+The bridge is bidirectional, so interactive UART input is also forwarded. It
+deliberately uses a /tmp pseudo-terminal rather than overwriting local
+/dev/ttyUSB0.
+
 UVHS Flow
 =========
 


### PR DESCRIPTION
## Summary
- add `bind_uart` to bridge a remote UART to a local PTY through SSH and socat
- enter a child shell with `FPGA_UART_PORT` exported for fpga-host
- document UART device, baud-rate, and PTY-path overrides

## Validation
- `make -s uart_env REMOTE=fpga`
- `make -n bind_uart REMOTE=fpga REMOTE_UART_PORT=/dev/ttyUSB1 REMOTE_UART_BAUD=9600 FPGA_UART_PORT=/tmp/custom-uart`
- start and exit `bind_uart` with a temporary PTY; verified cleanup
- `git diff --check`