### PR TITLE
fix(fpga_diff): support V3 partitions and ports

### DIFF
--- a/fpga_diff/core_flist.awk
+++ b/fpga_diff/core_flist.awk
@@ -1,4 +1,4 @@
-function simtop_has_dma(path, line, in_simtop) {
+function simtop_has_port(path, port, line, in_simtop) {
     while ((getline line < path) > 0) {
         if (!in_simtop && line ~ /^[[:space:]]*module[[:space:]]+/) {
             if (line !~ ("^[[:space:]]*module[[:space:]]+" top_module "([[:space:]#(]|$)")) {
@@ -7,7 +7,7 @@ function simtop_has_dma(path, line, in_simtop) {
             }
             in_simtop = 1
         }
-        if (in_simtop && line ~ /dma_awready/) {
+        if (in_simtop && line ~ port) {
             close(path)
             return 1
         }
@@ -25,8 +25,13 @@ BEGIN{
     printf "set %s [list \\\n", var
 }
 {
-    if (detect_simtop_dma && !has_simtop_dma && simtop_has_dma($0)) {
+    if (detect_simtop_dma && !has_simtop_dma &&
+        simtop_has_port($0, "dma_awready")) {
         has_simtop_dma = 1
+    }
+    if (detect_simtop_riscv_halt && !has_simtop_riscv_halt &&
+        simtop_has_port($0, "io_riscv_halt_0")) {
+        has_simtop_riscv_halt = 1
     }
     printf " [file normalize \"%s\" ]\\\n", $0
 }
@@ -34,5 +39,8 @@ END{
     printf "]\n"
     if (detect_simtop_dma) {
         printf "set cpu_files_has_dma %d\n", has_simtop_dma
+    }
+    if (detect_simtop_riscv_halt) {
+        printf "set cpu_files_has_riscv_halt %d\n", has_simtop_riscv_halt
     }
 }

--- a/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
+++ b/fpga_diff/src/rtl/kmh/SimTop_wrapper.sv
@@ -521,7 +521,9 @@ assign dma_core_rlast   = 1'b0;
   .io_cacheable_check_resp_1_instr   (),
   .io_cacheable_check_resp_1_mmio    (),
   .io_cacheable_check_resp_1_atomic    (),
+`ifdef CPU_XIANGSHAN_KMHV2
   .io_riscv_halt_0                     (),
+`endif
   .io_riscv_critical_error_0           (io_riscv_critical_error_0_int),
   .io_traceCoreInterface_0_fromEncoder_enable (trace_en),
   .io_traceCoreInterface_0_fromEncoder_stall  (trace_stall),

--- a/fpga_diff/src/tcl/common/xs_uart.tcl
+++ b/fpga_diff/src/tcl/common/xs_uart.tcl
@@ -150,6 +150,7 @@ foreach cpu_candidate $cpu_candidates {
 }
 # Legacy generated lists predate DMA capability metadata and expose DMA ports.
 set cpu_files_has_dma 1
+set cpu_files_has_riscv_halt 0
 set rtl_include_files [list]
 set rtl_include_dirs [list]
 if {[string equal $cpu_hit "no"]} {
@@ -232,6 +233,10 @@ if {$cpu_files_has_dma} {
     puts "INFO: SimTop DMA ports detected"
 } else {
     puts "INFO: SimTop DMA ports not present; wrapper DMA is tied off"
+}
+if {[string equal $cpu "kmh"] && $cpu_files_has_riscv_halt} {
+    fpga_append_unique defines "CPU_XIANGSHAN_KMHV2"
+    puts "INFO: Kunminghu V2 SimTop halt port detected"
 }
 if {!$no_diff} {
   set xdma_pcie_lanes 4

--- a/fpga_diff/tools/update_core_flist.sh
+++ b/fpga_diff/tools/update_core_flist.sh
@@ -45,7 +45,8 @@ generate_vivado_filelist() {
   fi
 
   tmp_output=$tmp_dir/cpu_files.tcl
-  awk -v var=cpu_files -v detect_simtop_dma=1 -v top_module="$top_module" \
+  awk -v var=cpu_files -v detect_simtop_dma=1 \
+    -v detect_simtop_riscv_halt=1 -v top_module="$top_module" \
     -f "$fpga_diff_dir/core_flist.awk" \
     "$tmp_dir/cpu_files" > "$tmp_output"
   awk -v var=rtl_include_files -f "$fpga_diff_dir/core_flist.awk" \
@@ -95,6 +96,10 @@ generate_uvhs_filelist() {
     if [[ $cpu == kmh ]] &&
       grep -Eq '^[[:space:]]*(input|output)[[:space:]].*dma_awready' "$core_rtl_dir/SimTop.sv"; then
       printf '+define+CONFIG_SIMTOP_HAS_DMA\n'
+    fi
+    if [[ $cpu == kmh ]] &&
+      grep -Eq '^[[:space:]]*output[[:space:]].*io_riscv_halt_0' "$core_rtl_dir/SimTop.sv"; then
+      printf '+define+CPU_XIANGSHAN_KMHV2\n'
     fi
 
     printf '+incdir+%s\n' "$core_dir" "$core_rtl_dir"

--- a/fpga_diff/uvhs/compilation/partition.tcl
+++ b/fpga_diff/uvhs/compilation/partition.tcl
@@ -28,13 +28,31 @@ set uvhs_config_path_names {
     core_def/U_SYS_CFG
     core_def/u_rom
 }
+set uvhs_cpu_is_kmhv2 0
+set uvhs_filelist ./rtl/filelist.f
+if {[file isfile $uvhs_filelist]} {
+    set uvhs_filelist_handle [open $uvhs_filelist r]
+    set uvhs_filelist_data [read $uvhs_filelist_handle]
+    close $uvhs_filelist_handle
+    set uvhs_cpu_is_kmhv2 [regexp -line \
+        {^\+define\+CPU_XIANGSHAN_KMHV2$} $uvhs_filelist_data]
+}
 set uvhs_host_path_names {
-    core_def/U_CPU_TOP/u_XSTop/soc/core_with_l2
     core_def/U_CPU_TOP/u_XSTop/endpoint
     core_def/U_CPU_TOP/u_XSTop/difftest_cfg
     core_def/U_CPU_TOP/u_XSTop/difftest_host
     core_def/U_CPU_TOP/u_XSTop/difftest_memCtrl
     core_def/xdma_ep_i
+}
+if {$uvhs_cpu_is_kmhv2} {
+    lappend uvhs_host_path_names \
+        core_def/U_CPU_TOP/u_XSTop/soc/core_with_l2
+} else {
+    set uvhs_l2_path_names {
+        core_def/U_CPU_TOP/u_XSTop/soc/core_with_l2/l2top
+    }
+    lappend uvhs_host_path_names \
+        core_def/U_CPU_TOP/u_XSTop/soc/core_with_l2/core
 }
 set uvhs_xiangshan_cell [get_cells -quiet {core_def/U_CPU_TOP/u_XSTop}]
 if {[llength $uvhs_xiangshan_cell] == 1} {
@@ -50,6 +68,14 @@ if {[llength $uvhs_xiangshan_cell] == 1} {
             [llength $uvhs_config_path_names] \
             [llength $uvhs_config_path_cells]]
     }
+    if {!$uvhs_cpu_is_kmhv2} {
+        set uvhs_l2_path_cells [get_cells -quiet $uvhs_l2_path_names]
+        if {[llength $uvhs_l2_path_cells] != [llength $uvhs_l2_path_names]} {
+            error [format "incomplete XiangShan L2 path: expected %d cells, got %d" \
+                [llength $uvhs_l2_path_names] \
+                [llength $uvhs_l2_path_cells]]
+        }
+    }
     set uvhs_host_path_cells [get_cells -quiet $uvhs_host_path_names]
     if {[llength $uvhs_host_path_cells] != [llength $uvhs_host_path_names]} {
         error [format "incomplete XiangShan host path: expected %d cells, got %d" \
@@ -58,6 +84,10 @@ if {[llength $uvhs_xiangshan_cell] == 1} {
     }
     set uvhs_f0_cells [concat $uvhs_f0_cells $uvhs_memory_path_cells \
         $uvhs_config_path_cells]
+    if {!$uvhs_cpu_is_kmhv2} {
+        create_fpga -name b0.f1 -cells $uvhs_l2_path_cells
+        puts "INFO: constrain XiangShan V3 L2 path to b0.f1: $uvhs_l2_path_cells"
+    }
     create_fpga -name b0.f2 -cells $uvhs_host_path_cells
     puts "INFO: constrain XiangShan host path to b0.f2: $uvhs_host_path_cells"
 } elseif {[llength $uvhs_xiangshan_cell]} {
@@ -85,11 +115,18 @@ if {[llength $uvhs_xiangshan_cell] == 1} {
     if {[llength $uvhs_clock_enable_net] != 1} {
         error "expected one DiffTest clock-enable net, got [llength $uvhs_clock_enable_net]"
     }
-    assign_route -signals $uvhs_clock_enable_net -path {b0.f2 b0.f0}
-    puts "INFO: constrain DiffTest clock enable to direct b0.f2-b0.f0 route"
+    if {$uvhs_cpu_is_kmhv2} {
+        set uvhs_clock_enable_path {b0.f2 b0.f0}
+    } else {
+        set uvhs_clock_enable_path {b0.f2 b0.f0 b0.f1}
+    }
+    assign_route -signals $uvhs_clock_enable_net -path $uvhs_clock_enable_path
+    puts "INFO: constrain DiffTest clock enable route: $uvhs_clock_enable_path"
 }
 unset -nocomplain uvhs_ddr_cell uvhs_ddr_connector \
     uvhs_bound_ddr_connector uvhs_f0_cells uvhs_memory_path_names \
     uvhs_memory_path_cells uvhs_config_path_names uvhs_config_path_cells \
+    uvhs_cpu_is_kmhv2 uvhs_filelist uvhs_filelist_handle uvhs_filelist_data \
+    uvhs_l2_path_names uvhs_l2_path_cells uvhs_clock_enable_path \
     uvhs_host_path_names uvhs_host_path_cells \
     uvhs_xiangshan_cell uvhs_clock_enable_net


### PR DESCRIPTION
## Summary

- Detect Kunminghu V2 from the generated SimTop io_riscv_halt_0 port.
- Define CPU_XIANGSHAN_KMHV2 for both Vivado and UVHS file lists.
- Guard the V2-only named halt-port connection in SimTop_wrapper.
- Keep the complete V2 core_with_l2 hierarchy on F2.
- Assign only V3 l2top to F1 while the V3 core and DiffTest host remain on F2.

## Compatibility

Kunminghu V2 exports io_riscv_halt_0. Kunminghu V3 replaces it with io_riscv_wfi_0. The UVHS file list is regenerated before backend partitioning, so the same detected version selects both wrapper and partition behavior.

## Verification

- Generated file lists from existing V2 and V3 FPGA releases.
- V2 emitted CPU_XIANGSHAN_KMHV2; V3 did not.
- Mocked UVHS partitioning: V2 created F0/F2 with route F2-F0; V3 created F0/F1/F2 with route F2-F0-F1.
- bash -n and Tcl completeness checks.