### PR TITLE
fix(fpga_diff): support LLC variants and boot flash

### DIFF
--- a/fpga_diff/src/tcl/common/blk_mem_gen_0.tcl
+++ b/fpga_diff/src/tcl/common/blk_mem_gen_0.tcl
@@ -65,7 +65,17 @@ proc write_blk_mem_gen_qspi { blk_mem_gen_qspi_filepath } {
 
   puts $blk_mem_gen_qspi {MEMORY_INITIALIZATION_RADIX=16;}
   puts $blk_mem_gen_qspi {MEMORY_INITIALIZATION_VECTOR=}
+  # The six words below match difftest/src/test/csrc/common/flash.cpp:
+  # csrrsi x0, mnstatus, 8     # 0x74446073 set mnstatus.nmie
+  # addiw  t0, zero, 1         # 0x0010029b
+  # slli   t1, t0, 42          # 0x02a29313
+  # csrrc  x0, mstatus, t1     # 0x30033073 clear mstatus.mdt
+  # slli   t0, t0, 31          # 0x01f29293
+  # jr     t0                  # 0x00028067 jump 0x80000000
+  puts $blk_mem_gen_qspi {74446073,}
   puts $blk_mem_gen_qspi {0010029b,}
+  puts $blk_mem_gen_qspi {02a29313,}
+  puts $blk_mem_gen_qspi {30033073,}
   puts $blk_mem_gen_qspi {01f29293,}
   puts $blk_mem_gen_qspi {00028067;}
 

--- a/fpga_diff/uvhs/compilation/partition.tcl
+++ b/fpga_diff/uvhs/compilation/partition.tcl
@@ -12,8 +12,16 @@ if {[llength $uvhs_ddr_cell] != 1} {
 # core and DiffTest host path with XDMA. UART pins remain on the physical F1
 # daughter card.
 set uvhs_f0_cells $uvhs_ddr_cell
-set uvhs_memory_path_names {
+# The LLC wrapper name depends on the XiangShan configuration: external-LLC
+# builds instantiate chi_extllc_opt, while the default OpenLLC build uses
+# chi_openllc_opt. Keep the variable root separate from the shared memory path
+# so one partition script works for either netlist and rejects an ambiguous one.
+set uvhs_memory_root_names {
     core_def/U_CPU_TOP/u_XSTop/soc/chi_extllc_opt
+    core_def/U_CPU_TOP/u_XSTop/soc/chi_openllc_opt
+}
+# These blocks are shared memory-path siblings of either LLC root.
+set uvhs_memory_path_names {
     core_def/U_CPU_TOP/u_XSTop/soc/imsic_bus_tops
     core_def/U_CPU_TOP/u_XSTop/soc/widget
     core_def/U_CPU_TOP/u_XSTop/soc/fragmenter
@@ -100,10 +108,17 @@ if {[llength $uvhs_xiangshan_cell] == 1} {
         error "incomplete nocMisc direct-child partition"
     }
 
-    set uvhs_memory_path_cells [get_cells -quiet $uvhs_memory_path_names]
-    if {[llength $uvhs_memory_path_cells] != [llength $uvhs_memory_path_names]} {
+    set uvhs_memory_root_cells [get_cells -quiet $uvhs_memory_root_names]
+    if {[llength $uvhs_memory_root_cells] != 1} {
+        error [format "expected exactly one XiangShan LLC path, got %d: %s" \
+            [llength $uvhs_memory_root_cells] $uvhs_memory_root_cells]
+    }
+    set uvhs_memory_path_cells [concat $uvhs_memory_root_cells \
+        [get_cells -quiet $uvhs_memory_path_names]]
+    if {[llength $uvhs_memory_path_cells] !=
+        [expr {[llength $uvhs_memory_path_names] + 1}]} {
         error [format "incomplete XiangShan memory path: expected %d cells, got %d" \
-            [llength $uvhs_memory_path_names] \
+            [expr {[llength $uvhs_memory_path_names] + 1}] \
             [llength $uvhs_memory_path_cells]]
     }
     set uvhs_memory_path_cells [concat $uvhs_memory_path_cells \
@@ -125,6 +140,7 @@ if {[llength $uvhs_xiangshan_cell] == 1} {
     set uvhs_f0_cells [concat $uvhs_f0_cells $uvhs_memory_path_cells \
         $uvhs_config_path_cells]
     create_fpga -name b0.f2 -cells $uvhs_host_path_cells
+    puts "INFO: selected XiangShan LLC path: $uvhs_memory_root_cells"
     puts "INFO: nocMisc direct children on b0.f0: $uvhs_nocmisc_f0_names"
     puts "INFO: nocMisc direct children on b0.f2: $uvhs_nocmisc_f2_names"
     puts "INFO: constrain XiangShan host path to b0.f2: $uvhs_host_path_cells"
@@ -168,8 +184,9 @@ if {[llength $uvhs_xiangshan_cell] == 1} {
     puts "INFO: constrain syscnt time bus to direct b0.f2-b0.f0 route"
 }
 unset -nocomplain uvhs_ddr_cell uvhs_ddr_connector \
-    uvhs_bound_ddr_connector uvhs_f0_cells uvhs_memory_path_names \
-    uvhs_memory_path_cells uvhs_config_path_names uvhs_config_path_cells \
+    uvhs_bound_ddr_connector uvhs_f0_cells uvhs_memory_root_names \
+    uvhs_memory_root_cells uvhs_memory_path_names uvhs_memory_path_cells \
+    uvhs_config_path_names uvhs_config_path_cells \
     uvhs_host_path_names uvhs_host_path_cells \
     uvhs_nocmisc_path uvhs_nocmisc_prefix uvhs_nocmisc_f0_anchors \
     uvhs_nocmisc_f2_children uvhs_nocmisc_direct_cells \


### PR DESCRIPTION
## Summary

- Accept either `chi_extllc_opt` or `chi_openllc_opt` as the XiangShan memory root.
- Require exactly one of the two hierarchy variants.
- Initialize `qspi.coe` with the six-instruction Kunminghu sequence from DiffTest `flash.cpp`, including `mnstatus` and `mstatus` CSR setup before jumping to `0x80000000`.
- Keep the `flash.cpp` assembly comments beside the corresponding Tcl COE words.

## Why the root/path split is written this way

The generated XiangShan hierarchy has one of two sibling LLC wrappers under `core_def/U_CPU_TOP/u_XSTop/soc`: ExtLLC builds use `chi_extllc_opt`, while the default OpenLLC build uses `chi_openllc_opt`. They are alternative root cells, not nested paths. The remaining memory-path cells (`nocMisc`, `imsic_bus_tops`, `widget`, `fragmenter`, `tl2axi4`, `axi4yank`, and `axi4buf`) are shared siblings, so the Tcl keeps the selected LLC root in a separate variable and concatenates it with the shared path list. The exact-one check fails early for a stale, unsupported, or ambiguous netlist instead of silently partitioning the wrong hierarchy. The selected memory/configuration cells are assigned to B0.F0 with DDR; the core/DiffTest host path remains on B0.F2.

## Hejian COE behavior

A fresh UVHS IP export loads `qspi.coe` into `blk_mem_gen_0`:

`uvhs_prepare -> compilation/prepare_ip.sh -> compilation/export_vivado_ip.tcl -> src/tcl/common/blk_mem_gen_0.tcl`

The Tcl writes `qspi.coe` into the generated IP directory, enables `CONFIG.Load_Init_File` and `CONFIG.Coe_File`, synthesizes the IP, and exports `rtl/soc/blk_mem_gen_0.dcp`. UVHS frontend imports that DCP; its initialized BRAM contents are then carried into the generated hardware database/bitstream. This is compile-time initialization of the AXI4 BRAM-backed flash model, not a runtime SPI flash programming operation. Existing cached DCPs must be regenerated with `UVHS_EXPORT_IP_FORCE=1` for a changed COE to take effect.

The separate `make uvhs_write_flash WORKLOAD=...` path starts the runtime server's `write_flash` command. It holds the CPU, writes the supplied image through the generalBus DMA path at base `0x0` (capacity `0x8000`), reads it back, and releases the CPU. This runtime write can override the initialized COE contents after download; it does not regenerate COE or the DCP.

## Verification

- Mocked both `chi_extllc_opt` and `chi_openllc_opt` partition hierarchies.
- Compared the COE words and comments with `difftest/src/test/csrc/common/flash.cpp`.
- Tcl completeness and `git diff --check` pass.
