### PR TITLE
feat(fpga_diff): probe DiffTrapEvent from XiangShan

### DIFF
--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -158,15 +158,16 @@ from the server's global Tcl scope.
 ## UVHS ILA Waveform Capture
 
 The probe scripts describe compile-time instrumentation, not a runtime dump.
-The frontend sources `compilation/probe_ila.tcl` by default. It samples only
-the XDMA host trigger on the free-running `core_def.sys_clk_i` parent clock.
-`compilation/probe_kmh.tcl` is the larger XiangShan profile derived from the
-2026-08-04 and 2026-08-07 debug builds. CPU and L2 signals are sampled on
+For XiangShan/KMH builds, the frontend sources `compilation/probe_kmh.tcl` by
+default. It is the larger XiangShan profile derived from the 2026-08-04 and
+2026-08-07 debug builds; CPU and L2 signals are sampled on
 `core_def.inter_soc_clk`, the gated clock connected to `SimTop.clock`. DDR and
 host-trigger signals remain on their free-running `core_def.sys_clk_i` domain,
 so the host trigger remains observable after the CPU clock stops. Its generated
 hierarchy must be checked before it is reused with a different XiangShan RTL
 revision. The braces preserve hierarchy indexes such as `[0]`.
+Other CPU builds continue to use the minimal `compilation/probe_ila.tcl`
+profile by default.
 Set `UVHS_PROBE_TCL` to select a profile or an external file; an override must
 retain the XDMA host trigger if host-controlled capture is required. Set it to
 an empty value for a build with no UHD instrumentation. The scripts call

--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -159,8 +159,7 @@ from the server's global Tcl scope.
 
 The probe scripts describe compile-time instrumentation, not a runtime dump.
 For XiangShan/KMH builds, the frontend sources `compilation/probe_kmh.tcl` by
-default. It is the larger XiangShan profile derived from the 2026-08-04 and
-2026-08-07 debug builds; CPU and L2 signals are sampled on
+default. CPU and L2 signals are sampled on
 `core_def.inter_soc_clk`, the gated clock connected to `SimTop.clock`. DDR and
 host-trigger signals remain on their free-running `core_def.sys_clk_i` domain,
 so the host trigger remains observable after the CPU clock stops. Its generated

--- a/fpga_diff/uvhs/compilation/probe_kmh.tcl
+++ b/fpga_diff/uvhs/compilation/probe_kmh.tcl
@@ -705,6 +705,7 @@ fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ct
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.timer \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.difftest_trap_instrCnt \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.hasWFI \
+fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.difftest_trap_coreid \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.io_frontend_toFtq_redirect_valid \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.io_frontend_toFtq_redirect_bits_cfiUpdate_target[49:0] \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.io_frontend_cfVec_0_valid \

--- a/fpga_diff/uvhs/compilation/probe_kmh.tcl
+++ b/fpga_diff/uvhs/compilation/probe_kmh.tcl
@@ -1,5 +1,6 @@
 # KMH probe paths derived from the 2026-08-04 and 2026-08-07 debug builds.
 # Signal paths must be checked when the generated XiangShan hierarchy changes.
+# DiffTrapEvent's hitTrap and instrCnt RHS values use generated trap-net names.
 probe_net -clock {fpga_top_debug.core_def.sys_clk_i} -add { \
 fpga_top_debug.core_def.U_UVHS_UVW_AXI4_TO_DDR4.ddr4ip_dut_axi_awaddr \
 fpga_top_debug.core_def.U_UVHS_UVW_AXI4_TO_DDR4.ddr4ip_dut_axi_awlen \
@@ -702,6 +703,9 @@ fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ct
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.io_commits_commitValid_6 \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.io_commits_commitValid_7 \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.io_commits_isCommit \
+fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.difftest_trap_hasTrap \
+fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.timer \
+fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.difftest_trap_instrCnt \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.inner_ctrlBlock.rob.hasWFI \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.io_frontend_toFtq_redirect_valid \
 fpga_top_debug.core_def.U_CPU_TOP.u_XSTop.soc.core_with_l2.core.backend.io_frontend_toFtq_redirect_bits_cfiUpdate_target[49:0] \

--- a/fpga_diff/uvhs/compilation/probe_kmh.tcl
+++ b/fpga_diff/uvhs/compilation/probe_kmh.tcl
@@ -1,6 +1,4 @@
-# KMH probe paths derived from the 2026-08-04 and 2026-08-07 debug builds.
 # Signal paths must be checked when the generated XiangShan hierarchy changes.
-# DiffTrapEvent's hitTrap and instrCnt RHS values use generated trap-net names.
 probe_net -clock {fpga_top_debug.core_def.sys_clk_i} -add { \
 fpga_top_debug.core_def.U_UVHS_UVW_AXI4_TO_DDR4.ddr4ip_dut_axi_awaddr \
 fpga_top_debug.core_def.U_UVHS_UVW_AXI4_TO_DDR4.ddr4ip_dut_axi_awlen \

--- a/fpga_diff/uvhs/uvhs.mk
+++ b/fpga_diff/uvhs/uvhs.mk
@@ -4,7 +4,8 @@ UVHS_RUNTIME_DIR := $(UVHS_ROOT_DIR)/uvhs/runtime
 
 UVHS_TEMPLATE_DIR ?=
 UVHS_UVW_AXI4_TO_DDR4_SRC ?=
-UVHS_PROBE_TCL ?= $(UVHS_COMPILATION_DIR)/probe_ila.tcl
+# KMH is the XiangShan target; keep the larger CPU profile enabled by default.
+UVHS_PROBE_TCL ?= $(if $(filter kmh xiangshan,$(CPU)),$(UVHS_COMPILATION_DIR)/probe_kmh.tcl,$(UVHS_COMPILATION_DIR)/probe_ila.tcl)
 UVHS_PROBE_PATH := $(if $(strip $(UVHS_PROBE_TCL)),$(abspath $(UVHS_PROBE_TCL)),)
 UVHS_DDR_AXI_WIDTH := $(if $(filter nutshell,$(CPU)),64,256)
 UVHS_WORK_DIR := $(ENV_SCRIPTS_HOME)/$(PRJ_NAME)

--- a/fpga_diff/vivado/vivado.mk
+++ b/fpga_diff/vivado/vivado.mk
@@ -6,9 +6,9 @@ PRJ_DIR ?= $(ENV_SCRIPTS_HOME)/$(PRJ_NAME)
 PRJ ?= $(PRJ_DIR)/$(PRJ_NAME).xpr
 CPU_FILES_TCL ?= $(PRJ_DIR)/cpu_files.tcl
 
-# Host-trigger ILA is enabled by default for XiangShan/KMH. Other CPU targets
-# retain the timing-friendly opt-in default and can override this variable.
-ENABLE_ILA ?= $(if $(filter kmh xiangshan,$(CPU)),1,0)
+# Host-trigger ILA capture is opt-in. Keep the trigger mark_debug net in RTL,
+# but avoid instantiating the ILA core by default to reduce routing pressure.
+ENABLE_ILA ?= 0
 ILA_DEPTH ?= 16384
 DDR_RANK_WIDTH ?= 2
 export ENABLE_ILA ILA_DEPTH DDR_RANK_WIDTH

--- a/fpga_diff/vivado/vivado.mk
+++ b/fpga_diff/vivado/vivado.mk
@@ -6,9 +6,9 @@ PRJ_DIR ?= $(ENV_SCRIPTS_HOME)/$(PRJ_NAME)
 PRJ ?= $(PRJ_DIR)/$(PRJ_NAME).xpr
 CPU_FILES_TCL ?= $(PRJ_DIR)/cpu_files.tcl
 
-# Host-trigger ILA capture is opt-in. Keep the trigger mark_debug net in RTL,
-# but avoid instantiating the ILA core by default to reduce routing pressure.
-ENABLE_ILA ?= 0
+# Host-trigger ILA is enabled by default for XiangShan/KMH. Other CPU targets
+# retain the timing-friendly opt-in default and can override this variable.
+ENABLE_ILA ?= $(if $(filter kmh xiangshan,$(CPU)),1,0)
 ILA_DEPTH ?= 16384
 DDR_RANK_WIDTH ?= 2
 export ENABLE_ILA ILA_DEPTH DDR_RANK_WIDTH


### PR DESCRIPTION
Use generated KMH trap nets for hitTrap and instrCnt while retaining timer and hasWFI in the UVHS probe profile. Select the profile and host-trigger ILA by default for kmh/XiangShan builds while preserving overrides and non-KMH timing defaults.