### PR TITLE
fix(fpga_diff): harden UVHS runtime handoff

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -57,7 +57,7 @@ uart_env:
 # Bridge REMOTE_UART_PORT through SSH to a local PTY for fpga-host.
 # Start an interactive shell with FPGA_UART_PORT exported after the bridge starts.
 bind_uart:
-	@test -n "$(REMOTE)" || { echo "REMOTE is required (for example: REMOTE=fpga-runtime)" >&2; exit 2; }
+	@test -n "$(REMOTE)" || { echo "REMOTE is required (for example: REMOTE=<user@fpga-runtime>)" >&2; exit 2; }
 	@command -v socat >/dev/null || { echo "socat is required on the local host" >&2; exit 2; }
 	@set -e; \
 	socat -d -d pty,link="$(FPGA_UART_PORT)",rawer,echo=0,waitslave \

--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -57,7 +57,7 @@ uart_env:
 # Bridge REMOTE_UART_PORT through SSH to a local PTY for fpga-host.
 # Start an interactive shell with FPGA_UART_PORT exported after the bridge starts.
 bind_uart:
-	@test -n "$(REMOTE)" || { echo "REMOTE is required (for example: REMOTE=fpga)" >&2; exit 2; }
+	@test -n "$(REMOTE)" || { echo "REMOTE is required (for example: REMOTE=fpga-runtime)" >&2; exit 2; }
 	@command -v socat >/dev/null || { echo "socat is required on the local host" >&2; exit 2; }
 	@set -e; \
 	socat -d -d pty,link="$(FPGA_UART_PORT)",rawer,echo=0,waitslave \

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -56,11 +56,13 @@ the remote UART to a local pseudo-terminal. `$UVHS_RUNTIME` owns UVHS and the
 physical UART while `$UVHS_HOST` owns XDMA and runs `fpga-host`. Install socat
 on both hosts, then start the bridge from `$UVHS_HOST`:
 
-    make bind_uart REMOTE=fpga-runtime
+    make bind_uart REMOTE=<user@fpga-runtime>
 
 The target bridges remote /dev/ttyUSB0 at 115200 baud to
 /tmp/fpga-remote-uart locally, exports FPGA_UART_PORT, and starts an
 interactive shell. Run fpga-host in that shell; leaving it stops the bridge.
+Replace the REMOTE placeholder with an SSH target resolvable from $UVHS_HOST;
+it may be a configured alias or a user@hostname destination.
 Override REMOTE_UART_PORT, REMOTE_UART_BAUD, or FPGA_UART_PORT when needed.
 For a scripted invocation, obtain the same environment assignment with:
 

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -51,11 +51,13 @@ FPGA_DDR_LOAD_CMD="bash -lc ' \
 Remote UART for fpga-host
 =========================
 
-When fpga-host runs on a machine other than the FPGA USB-UART host, bridge
-the remote UART to a local pseudo-terminal. Install socat on both hosts, then
-start the bridge:
+When `fpga-host` runs on a machine other than the FPGA USB-UART host, bridge
+the remote UART to a local pseudo-terminal. In the Hejian flow,
+`hejian-runtime` owns UVHS and the physical UART while `hejian-host` owns XDMA
+and runs `fpga-host`. Install socat on both hosts, then start the bridge from
+the host machine:
 
-    make bind_uart REMOTE=<user@fpga-host>
+    make bind_uart REMOTE=<user@runtime-host>
 
 The target bridges remote /dev/ttyUSB0 at 115200 baud to
 /tmp/fpga-remote-uart locally, exports FPGA_UART_PORT, and starts an
@@ -63,7 +65,7 @@ interactive shell. Run fpga-host in that shell; leaving it stops the bridge.
 Override REMOTE_UART_PORT, REMOTE_UART_BAUD, or FPGA_UART_PORT when needed.
 For a scripted invocation, obtain the same environment assignment with:
 
-    eval "$(make -s uart_env REMOTE=<user@fpga-host>)"
+    eval "$(make -s uart_env REMOTE=<user@runtime-host>)"
 
 The bridge is bidirectional, so interactive UART input is also forwarded. It
 deliberately uses a /tmp pseudo-terminal rather than overwriting local
@@ -81,4 +83,5 @@ make uvhs CPU=<design> CORE_DIR=/path/to/release/build SUFFIX=<tag>
 ```
 
 See [`uvhs/README.md`](uvhs/README.md) for the board-template and vendor-DDR
-inputs, build stages, and runtime commands.
+inputs, build stages, runtime commands, and the XDMA host refresh required for
+each runtime download.

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -52,12 +52,11 @@ Remote UART for fpga-host
 =========================
 
 When `fpga-host` runs on a machine other than the FPGA USB-UART host, bridge
-the remote UART to a local pseudo-terminal. In the Hejian flow,
-`hejian-runtime` owns UVHS and the physical UART while `hejian-host` owns XDMA
-and runs `fpga-host`. Install socat on both hosts, then start the bridge from
-the host machine:
+the remote UART to a local pseudo-terminal. `$UVHS_RUNTIME` owns UVHS and the
+physical UART while `$UVHS_HOST` owns XDMA and runs `fpga-host`. Install socat
+on both hosts, then start the bridge from `$UVHS_HOST`:
 
-    make bind_uart REMOTE=<user@runtime-host>
+    make bind_uart REMOTE=fpga-runtime
 
 The target bridges remote /dev/ttyUSB0 at 115200 baud to
 /tmp/fpga-remote-uart locally, exports FPGA_UART_PORT, and starts an
@@ -65,7 +64,7 @@ interactive shell. Run fpga-host in that shell; leaving it stops the bridge.
 Override REMOTE_UART_PORT, REMOTE_UART_BAUD, or FPGA_UART_PORT when needed.
 For a scripted invocation, obtain the same environment assignment with:
 
-    eval "$(make -s uart_env REMOTE=<user@runtime-host>)"
+    eval "$(make -s uart_env)"
 
 The bridge is bidirectional, so interactive UART input is also forwarded. It
 deliberately uses a /tmp pseudo-terminal rather than overwriting local

--- a/fpga_diff/tools/pcie-remove.sh
+++ b/fpga_diff/tools/pcie-remove.sh
@@ -1,23 +1,38 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Find BDF id of first xdma PCIE
-BDF=$(lspci -D | grep -i xilinx | awk '{print $1}' | head -n 1)
+# xdma_ep.tcl configures PF0 as 10ee:9048 for both supported XDMA IP versions.
+XDMA_PCI_ID=${XDMA_PCI_ID:-10ee:9048}
 
-if [ -z "$BDF" ]; then
-  echo "Warning: No Xilinx PCI device found."
-  exit 0
+mapfile -t FPGA_HOST_PROCESSES < <(
+  ps -eo pid=,comm=,args= | awk \
+    '$2 == "fpga-host" || $0 ~ /(^|[[:space:]\/])fpga-host([[:space:]]|$)/'
+)
+if ((${#FPGA_HOST_PROCESSES[@]} != 0)); then
+  echo "ERROR: fpga-host is still running; stop it before removing the XDMA endpoint:" >&2
+  printf '  %s\n' "${FPGA_HOST_PROCESSES[@]}" >&2
+  exit 1
 fi
 
-# Unbind xdma driver first to avoid kernel oops in remove_one callback
-if [ -e "/sys/bus/pci/devices/$BDF/driver" ]; then
+mapfile -t BDFS < <(lspci -D -d "$XDMA_PCI_ID" | awk '{print $1}')
+if ((${#BDFS[@]} == 0)); then
+  echo "WARNING: no XDMA PCI device found for $XDMA_PCI_ID"
+  exit 0
+fi
+if ((${#BDFS[@]} != 1)); then
+  echo "ERROR: expected one XDMA PCI device for $XDMA_PCI_ID, found ${#BDFS[@]}:" >&2
+  printf '  %s\n' "${BDFS[@]}" >&2
+  exit 1
+fi
+BDF=${BDFS[0]}
+
+# Unbind first so the driver does not retain state across FPGA reprogramming.
+if [[ -e /sys/bus/pci/devices/$BDF/driver ]]; then
   DRIVER=$(basename "$(readlink /sys/bus/pci/devices/$BDF/driver)")
   echo "Unbinding driver '$DRIVER' from $BDF"
-  echo "$BDF" | sudo tee /sys/bus/pci/drivers/$DRIVER/unbind >/dev/null
+  printf '%s\n' "$BDF" | sudo -n tee "/sys/bus/pci/drivers/$DRIVER/unbind" >/dev/null
   sleep 1
 fi
 
-# Remove PCIE of xdma
-echo "PCI device BDF id: $BDF"
-echo 1 | sudo tee /sys/bus/pci/devices/$BDF/remove
-echo "Removing PCI device at $BDF"
+echo "Removing XDMA PCI device $BDF ($XDMA_PCI_ID)"
+printf '1\n' | sudo -n tee "/sys/bus/pci/devices/$BDF/remove" >/dev/null

--- a/fpga_diff/tools/pcie-rescan.sh
+++ b/fpga_diff/tools/pcie-rescan.sh
@@ -1,4 +1,55 @@
 #!/bin/bash
-set -e
-echo 1 | sudo tee /sys/bus/pci/rescan >/dev/null
-echo "Rescan PCI device successfully"
+set -euo pipefail
+
+XDMA_PCI_ID=${XDMA_PCI_ID:-10ee:9048}
+XDMA_RESCAN_TIMEOUT=${XDMA_RESCAN_TIMEOUT:-30}
+REQUIRED_NODES=(
+  /dev/xdma0_h2c_0
+  /dev/xdma0_c2h_0
+  /dev/xdma0_user
+)
+
+[[ $XDMA_RESCAN_TIMEOUT =~ ^[1-9][0-9]*$ ]] || {
+  echo "ERROR: XDMA_RESCAN_TIMEOUT must be a positive integer" >&2
+  exit 2
+}
+
+printf '1\n' | sudo -n tee /sys/bus/pci/rescan >/dev/null
+
+BDF=
+for ((elapsed = 0; elapsed < XDMA_RESCAN_TIMEOUT; elapsed++)); do
+  BDF=$(lspci -D -d "$XDMA_PCI_ID" | awk 'NR == 1 {print $1}')
+  if [[ -n $BDF && -e /sys/bus/pci/devices/$BDF/driver ]]; then
+    DRIVER=$(basename "$(readlink /sys/bus/pci/devices/$BDF/driver)")
+    nodes_ready=1
+    for node in "${REQUIRED_NODES[@]}"; do
+      [[ -c $node ]] || nodes_ready=0
+    done
+    if [[ $DRIVER == xdma-chr && $nodes_ready == 1 ]]; then
+      break
+    fi
+  fi
+  BDF=
+  sleep 1
+done
+
+if [[ -z $BDF ]]; then
+  echo "ERROR: XDMA did not become ready within ${XDMA_RESCAN_TIMEOUT}s" >&2
+  lspci -Dnnk -d "$XDMA_PCI_ID" >&2 || true
+  ls -l /dev/xdma0_* >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "XDMA PCI device:"
+lspci -Dnnk -s "$BDF"
+echo "XDMA device nodes:"
+ls -l /dev/xdma0_*
+
+for node in "${REQUIRED_NODES[@]}"; do
+  if [[ ! -r $node || ! -w $node ]]; then
+    echo "ERROR: $node is not readable and writable by $(id -un); check the XDMA udev rule" >&2
+    exit 1
+  fi
+done
+
+echo "XDMA rescan completed successfully"

--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -128,12 +128,12 @@ database and calling `initialize` without `download` fails. Start the next
 runtime session with `uvhs_write_bitstream` so it reloads and downloads
 `hw.dat`.
 
-The UVHS runtime host does not control the Linux PCIe endpoint on the XDMA host.
-Around every runtime download, remove `10ee:9048` on the XDMA host before this
-target and rescan it afterward. The playground-level `write_bitstream` target
-performs this cross-host sequence when `FPGA_HOST_REMOTE` is set. The rescan
-waits for `xdma-chr`, prints the endpoint and device nodes, and verifies access;
-an installed XDMA udev rule avoids a separate `sudo chmod`.
+`$UVHS_RUNTIME` does not control the Linux PCIe endpoint on `$UVHS_HOST`. Around
+every runtime download, remove `10ee:9048` on `$UVHS_HOST` before this target
+and rescan it afterward. The playground-level `write_bitstream` target performs
+this cross-host sequence when `UVHS_HOST` is set. The rescan waits for
+`xdma-chr`, prints the endpoint and device nodes, and verifies access; an
+installed XDMA udev rule avoids a separate `sudo chmod`.
 
 `uvhs_write_ddr` converts the Vivado address/data-pair format to the DDR DCP
 word width and calls `writemem -rtl`. It leaves the CPU halted until
@@ -270,15 +270,16 @@ by trigger/capture cleanup:
 
 ```sh
 eval "$(make -s ila_host_env FPGA_BACKEND=uvhs \
-  CPU=<design> SUFFIX=<tag> UVHS_RUNTIME=<runtime-host>)"
+  CPU=<design> SUFFIX=<tag> UVHS_RUNTIME=$UVHS_RUNTIME)"
 
 /path/to/fpga-host <host arguments>
 ```
 
 The arm command must use the same runtime work directory as
-`uvhs_write_bitstream`. If the FPGA host and UVHS runtime are on one machine,
-omit `ssh <runtime-host>`. The trigger signal must be listed in the compile-time
-`trigger_net` group; adding it to RTL with `mark_debug` alone is not sufficient.
+`uvhs_write_bitstream`. If `$UVHS_HOST` and `$UVHS_RUNTIME` name the same
+machine, omit the generated SSH wrapper. The trigger signal must be listed in
+the compile-time `trigger_net` group; adding it to RTL with `mark_debug` alone
+is not sufficient.
 
 The generated upload hook clears the trigger after a normal host-triggered
 capture. Clear it explicitly after an interrupted or independently armed

--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -128,6 +128,13 @@ database and calling `initialize` without `download` fails. Start the next
 runtime session with `uvhs_write_bitstream` so it reloads and downloads
 `hw.dat`.
 
+The UVHS runtime host does not control the Linux PCIe endpoint on the XDMA host.
+Around every runtime download, remove `10ee:9048` on the XDMA host before this
+target and rescan it afterward. The playground-level `write_bitstream` target
+performs this cross-host sequence when `FPGA_HOST_REMOTE` is set. The rescan
+waits for `xdma-chr`, prints the endpoint and device nodes, and verifies access;
+an installed XDMA udev rule avoids a separate `sudo chmod`.
+
 `uvhs_write_ddr` converts the Vivado address/data-pair format to the DDR DCP
 word width and calls `writemem -rtl`. It leaves the CPU halted until
 `uvhs_reset_cpu` is issued.
@@ -136,7 +143,9 @@ word width and calls `writemem -rtl`. It leaves the CPU halted until
 `query -ipinfo -tclobj`, then writes through its 64-bit AXI port and the
 existing 32-bit AXI flash bridge. The generalBus view starts at offset zero;
 the CPU and normal JTAG address map are unchanged. A complete readback match
-is required before the command succeeds.
+is required before the command succeeds. The command holds the CPU while the
+boot image changes and releases it after the verified write; callers do not
+need a separate `uvhs_halt_soc` command.
 
 The runtime implementation has two control layers:
 
@@ -226,8 +235,10 @@ test0
 Waveform capture is split around the host run. `uvhs_ila_arm` validates and
 installs the trigger condition, starts capture, and returns immediately. It
 does not reset or release the CPU. `uvhs_ila_upload` waits for an armed
-trigger, uploads the UHD data, reconstructs the waveform database, and calls
-`uvhs_vcd`. The standalone `uvhs_vcd` target repeats only the USDB-to-VCD
+trigger, uploads the UHD data, reconstructs the waveform database, calls
+`uvhs_vcd`, and restores any clock reduced for capture bandwidth. The
+host-generated upload hook then calls `uvhs_ila_clear`, including after an
+upload failure. The standalone `uvhs_vcd` target repeats only the USDB-to-VCD
 conversion. The commands create both files below the selected build directory:
 
 ```text
@@ -251,23 +262,17 @@ trigger -status -wait 1 -timeout 60
 upload_uhd -depth 1000000 -position 0 -clock clk5_p -out uvhs_ila
 ```
 
-The FPGA host clears `HOST_IO_ILA_TRIGGER`, invokes `FPGA_ILA_DUMP_CMD`, and
-then releases the CPU. It raises that signal at Good Trap or DiffTest failure.
-Use `uvhs_ila_arm` as the hook so capture starts before the host releases the
-CPU and the requested history precedes the host trigger:
+The FPGA host clears `HOST_IO_ILA_TRIGGER`, invokes `FPGA_ILA_ARM_CMD`, and then
+releases the CPU. It raises that signal at Good Trap or DiffTest failure, then
+invokes `FPGA_ILA_UPLOAD_CMD` during normal host cleanup. Generate both hooks
+with `ila_host_env` so capture starts before CPU release and upload is followed
+by trigger/capture cleanup:
 
 ```sh
-export FPGA_ILA_DUMP_CMD='ssh <runtime-host> \
-  "make -C /path/to/env-scripts/fpga_diff uvhs_ila_arm \
-  CPU=<design> SUFFIX=<tag> \
-  TRIGGER=/path/to/env-scripts/fpga_diff/uvhs/runtime/trigger.ini \
-  UVHS_ILA_POSITION=0 \
-  UVHS_ILA_GATED_CLOCK=<capture-clock-0>,<capture-clock-1>"'
+eval "$(make -s ila_host_env FPGA_BACKEND=uvhs \
+  CPU=<design> SUFFIX=<tag> UVHS_RUNTIME=<runtime-host>)"
 
 /path/to/fpga-host <host arguments>
-
-# Run on the runtime host after fpga-host exits.
-make uvhs_ila_upload CPU=<design> SUFFIX=<tag>
 ```
 
 The arm command must use the same runtime work directory as
@@ -275,7 +280,9 @@ The arm command must use the same runtime work directory as
 omit `ssh <runtime-host>`. The trigger signal must be listed in the compile-time
 `trigger_net` group; adding it to RTL with `mark_debug` alone is not sufficient.
 
-Clear the trigger configuration after a timed-out or unwanted capture with:
+The generated upload hook clears the trigger after a normal host-triggered
+capture. Clear it explicitly after an interrupted or independently armed
+capture with:
 
 ```sh
 make uvhs_ila_clear CPU=<design> SUFFIX=<tag>

--- a/fpga_diff/uvhs/runtime/ila_host_env.sh
+++ b/fpga_diff/uvhs/runtime/ila_host_env.sh
@@ -50,6 +50,19 @@ upload_command=$(make_command ila_upload \
   "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name" \
   "UVHS_ILA_TIMEOUT=$timeout" \
   "UVHS_ILA_DEPTH=$depth" "UVHS_ILA_CLOCK=$clock")
+clear_command=$(make_command ila_clear \
+  "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name")
+runtime_stop_command=$(make_command runtime_stop \
+  "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name")
+
+# Preserve an upload failure while always releasing the capture and restoring
+# any clock temporarily reduced for UHD bandwidth.
+upload_and_clear_command="upload_status=0; $upload_command || upload_status=\$?;"
+upload_and_clear_command+=" clear_status=0; $clear_command || clear_status=\$?;"
+upload_and_clear_command+=" test \$upload_status -eq 0 || exit \$upload_status;"
+upload_and_clear_command+=" exit \$clear_status"
 
 printf 'export FPGA_ILA_ARM_CMD=%q\n' "$arm_command"
-printf 'export FPGA_ILA_UPLOAD_CMD=%q\n' "$upload_command"
+printf 'export FPGA_ILA_UPLOAD_CMD=%q\n' "$upload_and_clear_command"
+printf 'export FPGA_ILA_CLEAR_CMD=%q\n' "$clear_command"
+printf 'export FPGA_RUNTIME_STOP_CMD=%q\n' "$runtime_stop_command"

--- a/fpga_diff/uvhs/runtime/runtime_server.tcl
+++ b/fpga_diff/uvhs/runtime/runtime_server.tcl
@@ -254,7 +254,25 @@ proc uvhs_query_clock_frequency {clock} {
     return [lindex $frequencies 0]
 }
 
-proc uvhs_configure_tmclk_from_cpu {} {
+proc uvhs_query_default_clock_frequency {clock} {
+    set frequencies {}
+    foreach line [split [query -clock -default -tclobj] "\n"] {
+        set fields [regexp -all -inline {\S+} $line]
+        if {[llength $fields] >= 6 && [lindex $fields 4] eq $clock &&
+            [string is double -strict [lindex $fields 3]]} {
+            lappend frequencies [expr {
+                round(double([lindex $fields 3]) * 1000000.0)
+            }]
+        }
+    }
+    set frequencies [lsort -integer -unique $frequencies]
+    if {[llength $frequencies] != 1} {
+        error "expected one default frequency for clock $clock, got $frequencies"
+    }
+    return [lindex $frequencies 0]
+}
+
+proc uvhs_configure_tmclk_from_cpu {{cpu_frequency ""}} {
     # Keep the CPU-to-TMCLK relationship stable across sign-off frequencies.
     # The environment variable remains available for controlled experiments,
     # while the normal Make/runtime path supplies the fixed 50:1 default.
@@ -268,7 +286,9 @@ proc uvhs_configure_tmclk_from_cpu {} {
         error "TMCLK-to-CPU clock ratio must be positive: $ratio"
     }
 
-    set cpu_frequency [uvhs_query_clock_frequency clk5_p]
+    if {$cpu_frequency eq ""} {
+        set cpu_frequency [uvhs_query_clock_frequency clk5_p]
+    }
     set tmclk_frequency [expr {round(double($cpu_frequency) / $ratio)}]
     if {$tmclk_frequency <= 0} {
         error "derived TMCLK frequency is invalid: $tmclk_frequency"
@@ -609,7 +629,9 @@ proc uvhs_initialize_runtime {} {
     # Keep clk5_p at the system sign-off frequency committed in this runtime DB.
     # It varies with the partition and PnR result, so it must not be hard-coded.
     config -clock -name clk6_p -frequency 50000000
-    uvhs_configure_tmclk_from_cpu
+    set signoff_cpu_frequency [uvhs_query_default_clock_frequency clk5_p]
+    config -clock -name clk5_p -frequency $signoff_cpu_frequency
+    uvhs_configure_tmclk_from_cpu $signoff_cpu_frequency
     config -clock -commit
     query -clock
 

--- a/fpga_diff/uvhs/uvhs.mk
+++ b/fpga_diff/uvhs/uvhs.mk
@@ -206,8 +206,8 @@ uvhs_ila_upload:
 	$(MAKE) uvhs_vcd
 	@echo "UVHS_ILA_USDB=$(UVHS_ILA_USDB)"
 
-# Print sourceable hooks for fpga-host. The generated commands use the public
-# backend targets so callers do not depend on UVHS implementation names.
+# Print sourceable host/runtime lifecycle commands. They use the public backend
+# targets so callers do not depend on UVHS implementation names.
 uvhs_ila_host_env:
 	@bash "$(UVHS_RUNTIME_DIR)/ila_host_env.sh" \
 		"$(UVHS_RUNTIME)" "$(UVHS_ILA_DIR)" \

--- a/fpga_diff/vivado/vivado.mk
+++ b/fpga_diff/vivado/vivado.mk
@@ -81,10 +81,8 @@ vivado_write_ddr:
 		-tclargs $(WORKLOAD) $(AXI_WIDTH)
 
 vivado_write_flash:
-	$(MAKE) vivado_halt_soc
 	vivado -mode tcl -source "$(VIVADO_SCRIPT_DIR)/jtag_write_flash.tcl" \
 		-tclargs $(WORKLOAD)
-	$(MAKE) vivado_reset_cpu
 
 vivado_reset_cpu:
 	@test -n "$(FPGA_BIT_HOME)" || { echo "ERROR: please set FPGA_BIT_HOME=..." >&2; exit 2; }

--- a/fpga_diff/vivado/vivado.mk
+++ b/fpga_diff/vivado/vivado.mk
@@ -81,8 +81,10 @@ vivado_write_ddr:
 		-tclargs $(WORKLOAD) $(AXI_WIDTH)
 
 vivado_write_flash:
+	$(MAKE) vivado_halt_soc
 	vivado -mode tcl -source "$(VIVADO_SCRIPT_DIR)/jtag_write_flash.tcl" \
 		-tclargs $(WORKLOAD)
+	$(MAKE) vivado_reset_cpu
 
 vivado_reset_cpu:
 	@test -n "$(FPGA_BIT_HOME)" || { echo "ERROR: please set FPGA_BIT_HOME=..." >&2; exit 2; }


### PR DESCRIPTION
Match the configured 10ee:9048 endpoint, reject active fpga-host users, and report driver and device-node state after PCIe rescan.

Make flash writes self-protecting and generate ILA clear and runtime stop commands for host-side lifecycle cleanup.