### PR TITLE
feat(fpga_diff): support split-host UVHS workflows

### DIFF
--- a/fpga_diff/Makefile
+++ b/fpga_diff/Makefile
@@ -12,10 +12,9 @@ NO_DIFF ?= 0
 XDMA_LINK_WIDTH ?= X4
 VIVADO_JOBS ?=
 export XDMA_LINK_WIDTH VIVADO_JOBS NO_DIFF
-REMOTE ?=
-REMOTE_UART_PORT ?= /dev/ttyUSB0
-REMOTE_UART_BAUD ?= 115200
-FPGA_UART_PORT ?= /tmp/fpga-remote-uart
+FPGA_RUNTIME ?=
+REMOTE_ENV ?= source ~/.bash_profile &&
+BIND_UART ?= 1
 # Supported CPU parameters:
 #   kmh
 #   nutshell
@@ -27,13 +26,13 @@ ifeq ($(filter nodiff nodiff-%,$(SUFFIX)),)
 override SUFFIX := nodiff$(if $(strip $(SUFFIX)),-$(strip $(SUFFIX)),)
 endif
 endif
-PRJ_NAME ?= fpga_$(FPGA_BACKEND)_$(CPU)$(if $(strip $(SUFFIX)),-$(strip $(SUFFIX)),)
+override PRJ_NAME := fpga_$(FPGA_BACKEND)_$(CPU)$(if $(strip $(SUFFIX)),-$(strip $(SUFFIX)),)
 export PRJ_NAME
 FPGA_DISPATCH_TARGETS := project bitstream stage_bitstream write_bitstream halt_soc \
 	write_ddr write_flash reset_cpu runtime_status runtime_stop \
-	ila_arm ila_upload ila_clear ila_host_env
+	ila_arm ila_upload ila_clear host_env
 
-.PHONY: $(FPGA_DISPATCH_TARGETS) check_project_name bind_uart uart_env
+.PHONY: $(FPGA_DISPATCH_TARGETS) check_project_name pcie_remove pcie_rescan
 
 check_project_name:
 	@case "$$PRJ_NAME" in \
@@ -50,23 +49,11 @@ $(FPGA_DISPATCH_TARGETS): check_project_name
 	}
 	+@$(MAKE) --no-print-directory $(FPGA_BACKEND)_$@
 
-# Print the environment assignment consumed by fpga-host.
-uart_env:
-	@printf 'export FPGA_UART_PORT=%s\n' '$(FPGA_UART_PORT)'
+pcie_remove:
+	bash "$(CURDIR)/tools/pcie-remove.sh"
 
-# Bridge REMOTE_UART_PORT through SSH to a local PTY for fpga-host.
-# Start an interactive shell with FPGA_UART_PORT exported after the bridge starts.
-bind_uart:
-	@test -n "$(REMOTE)" || { echo "REMOTE is required (for example: REMOTE=<user@fpga-runtime>)" >&2; exit 2; }
-	@command -v socat >/dev/null || { echo "socat is required on the local host" >&2; exit 2; }
-	@set -e; \
-	socat -d -d pty,link="$(FPGA_UART_PORT)",rawer,echo=0,waitslave \
-		EXEC:"ssh -T $(REMOTE) 'exec socat - $(REMOTE_UART_PORT),rawer,b$(REMOTE_UART_BAUD)'",nofork & \
-	bridge_pid=$$!; \
-	trap 'kill $$bridge_pid 2>/dev/null || true; wait $$bridge_pid 2>/dev/null || true' 0 INT TERM; \
-	export FPGA_UART_PORT="$(FPGA_UART_PORT)"; \
-	printf 'FPGA_UART_PORT=%s\n' "$$FPGA_UART_PORT"; \
-	$(SHELL) -i
+pcie_rescan:
+	bash "$(CURDIR)/tools/pcie-rescan.sh"
 
 include vivado/vivado.mk
 include uvhs/uvhs.mk

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -18,7 +18,22 @@ Core RTL to FPGA Steps
   chmod u+x tools/pcie-remove.sh
   chmod u+x tools/pcie-rescan.sh
 
-6. make write_bitstream
+6. Program the FPGA. The Vivado backend removes and rescans its local XDMA
+endpoint around programming:
+
+```shell
+make write_bitstream FPGA_BACKEND=<vivado-or-uvhs> \
+  FPGA_BIT_HOME=/path/to/vivado-bitstream
+```
+
+For a split-host backend, env-scripts also exposes local `pcie_remove` and
+`pcie_rescan` targets. The caller runs them on the XDMA host before and after
+`write_bitstream` on the runtime host. Rescan rejects an all-`ff` PCI
+configuration read even if stale device nodes still exist.
+
+`PRJ_NAME` is derived from `FPGA_BACKEND`, `CPU`, and `SUFFIX`. A staged UVHS
+runtime artifact must be copied to the printed relative destination under this
+checkout so the derived project directory contains `hw.dat`.
 
 7. write DDR and run with diff/no-diff
 ```shell
@@ -30,47 +45,33 @@ make write_ddr FPGA_BACKEND=vivado
 make reset_cpu
 
 case 2: With fpga-host (no-diff mode)
-FPGA_DDR_LOAD_CMD="bash -lc ' \
-  source ~/.bash_profile && \
-  make -C /path/to/fpga_diff write_ddr FPGA_BACKEND=vivado \
-    FPGA_BIT_HOME=... \
-    WORKLOAD=<workload>.txt \
-'" \
 ./fpga-host --no-diff
 
 case 3: With fpga-host (diff mode)
-FPGA_DDR_LOAD_CMD="bash -lc ' \
-  source ~/.bash_profile && \
-  make -C /path/to/fpga_diff write_ddr FPGA_BACKEND=vivado \
-    FPGA_BIT_HOME=... \
-    WORKLOAD=<workload>.txt \
-'" \
 ./fpga-host --diff <nemu> -i <workload>.bin
 ```
 
-Remote UART for fpga-host
-=========================
+fpga-host environment
+=====================
 
-When `fpga-host` runs on a machine other than the FPGA USB-UART host, bridge
-the remote UART to a local pseudo-terminal. `$UVHS_RUNTIME` owns UVHS and the
-physical UART while `$UVHS_HOST` owns XDMA and runs `fpga-host`. Install socat
-on both hosts, then start the bridge from `$UVHS_HOST`:
+Run `host_env` on the XDMA host immediately before `fpga-host`:
 
-    make bind_uart REMOTE=<user@fpga-runtime>
+    eval "$(make -s host_env FPGA_BACKEND=uvhs CPU=<design> \
+      FPGA_RUNTIME=<user@fpga-runtime> WORKLOAD=/path/to/workload.txt)"
+    trap 'eval "${FPGA_HOST_CLEANUP_CMD:-:}"' EXIT
+    /path/to/fpga-host ...
 
-The target bridges remote /dev/ttyUSB0 at 115200 baud to
-/tmp/fpga-remote-uart locally, exports FPGA_UART_PORT, and starts an
-interactive shell. Run fpga-host in that shell; leaving it stops the bridge.
-Replace the REMOTE placeholder with an SSH target resolvable from $UVHS_HOST;
-it may be a configured alias or a user@hostname destination.
-Override REMOTE_UART_PORT, REMOTE_UART_BAUD, or FPGA_UART_PORT when needed.
-For a scripted invocation, obtain the same environment assignment with:
+- Exports ILA arm/upload hooks; upload always follows with `ila_clear`.
+- Exports a DDR fallback hook when `WORKLOAD` is set; H2C-enabled hosts ignore it.
+- By default, bridges runtime `/dev/ttyUSB0` to a host PTY and exports
+  `FPGA_UART_PORT`; set `BIND_UART=0` to skip it.
+- Exports `FPGA_HOST_CLEANUP_CMD` for the caller to release the UART bridge.
 
-    eval "$(make -s uart_env)"
+`FPGA_RUNTIME` may be an SSH alias or `user@hostname` resolvable from the FPGA
+host. UART binding requires `socat` on both machines.
 
-The bridge is bidirectional, so interactive UART input is also forwarded. It
-deliberately uses a /tmp pseudo-terminal rather than overwriting local
-/dev/ttyUSB0.
+`runtime_stop` releases the UVHS runtime session and is a no-op for Vivado, so
+callers can invoke the backend-neutral target after `fpga-host` exits.
 
 UVHS Flow
 =========

--- a/fpga_diff/README.md
+++ b/fpga_diff/README.md
@@ -58,17 +58,18 @@ Run `host_env` on the XDMA host immediately before `fpga-host`:
 
     eval "$(make -s host_env FPGA_BACKEND=uvhs CPU=<design> \
       FPGA_RUNTIME=<user@fpga-runtime> WORKLOAD=/path/to/workload.txt)"
-    trap 'eval "${FPGA_HOST_CLEANUP_CMD:-:}"' EXIT
+    trap "${FPGA_HOST_CLEANUP_CMD:-:}" 0
     /path/to/fpga-host ...
 
 - Exports ILA arm/upload hooks; upload always follows with `ila_clear`.
 - Exports a DDR fallback hook when `WORKLOAD` is set; H2C-enabled hosts ignore it.
 - By default, bridges runtime `/dev/ttyUSB0` to a host PTY and exports
-  `FPGA_UART_PORT`; set `BIND_UART=0` to skip it.
+  `FPGA_UART_PORT`; it fails if another process is already reading the physical
+  UART. Set `BIND_UART=0` to skip it.
 - Exports `FPGA_HOST_CLEANUP_CMD` for the caller to release the UART bridge.
 
 `FPGA_RUNTIME` may be an SSH alias or `user@hostname` resolvable from the FPGA
-host. UART binding requires `socat` on both machines.
+host. UART binding requires `socat` on both machines and `fuser` on the runtime.
 
 `runtime_stop` releases the UVHS runtime session and is a no-op for Vivado, so
 callers can invoke the backend-neutral target after `fpga-host` exits.

--- a/fpga_diff/tools/pcie-rescan.sh
+++ b/fpga_diff/tools/pcie-rescan.sh
@@ -17,15 +17,19 @@ REQUIRED_NODES=(
 printf '1\n' | sudo -n tee /sys/bus/pci/rescan >/dev/null
 
 BDF=
+CONFIG_DWORD=
 for ((elapsed = 0; elapsed < XDMA_RESCAN_TIMEOUT; elapsed++)); do
   BDF=$(lspci -D -d "$XDMA_PCI_ID" | awk 'NR == 1 {print $1}')
   if [[ -n $BDF && -e /sys/bus/pci/devices/$BDF/driver ]]; then
     DRIVER=$(basename "$(readlink /sys/bus/pci/devices/$BDF/driver)")
+    CONFIG_DWORD=$(od -An -tx4 -N4 "/sys/bus/pci/devices/$BDF/config" \
+      2>/dev/null | tr -d '[:space:]')
     nodes_ready=1
     for node in "${REQUIRED_NODES[@]}"; do
       [[ -c $node ]] || nodes_ready=0
     done
-    if [[ $DRIVER == xdma-chr && $nodes_ready == 1 ]]; then
+    if [[ $DRIVER == xdma-chr && $nodes_ready == 1 && \
+          -n $CONFIG_DWORD && $CONFIG_DWORD != ffffffff ]]; then
       break
     fi
   fi
@@ -42,6 +46,7 @@ fi
 
 echo "XDMA PCI device:"
 lspci -Dnnk -s "$BDF"
+echo "XDMA PCI config dword 0: $CONFIG_DWORD"
 echo "XDMA device nodes:"
 ls -l /dev/xdma0_*
 

--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -123,15 +123,27 @@ the hardware, and keeps a detached UVHS session alive. Later reset and memory
 commands must use that same session. Its PID, command files, and log are stored
 under `runtime-work` in the selected build directory. The session has no idle
 timeout; use `uvhs_runtime_stop` after testing to release it cleanly.
+`uvhs_stage_bitstream` copies `hw.dat` into
+`runtime/<derived-project-name>/` inside the bit archive. It prints both the
+source artifact and its relative destination under `env-scripts/fpga_diff` so
+the runtime checkout can locate it without another path variable.
 After the session stops, the released FPGA reports link down; loading the same
 database and calling `initialize` without `download` fails. Start the next
 runtime session with `uvhs_write_bitstream` so it reloads and downloads
 `hw.dat`.
 
-`$UVHS_RUNTIME` does not control the Linux PCIe endpoint on `$UVHS_HOST`. Around
-every runtime download, remove `10ee:9048` on `$UVHS_HOST` before this target
-and rescan it afterward. The playground-level `write_bitstream` target performs
-this cross-host sequence when `UVHS_HOST` is set. The rescan waits for
+`host_env` exports ILA arm/upload and DDR fallback settings for `fpga-host`.
+With `BIND_UART=1` (the default), it also creates and exports a run-scoped UART
+bridge; set `BIND_UART=0` to skip it. Upload clears ILA state before returning.
+Remote hooks source `REMOTE_ENV`, which defaults to
+`source ~/.bash_profile &&` and can be overridden by the caller.
+Internally, `ila_host_env.sh` generates the ILA/DDR hooks and `bind_uart.sh`
+generates the optional UART settings.
+
+`$FPGA_RUNTIME` does not control the Linux PCIe endpoint on `$FPGA_HOST`.
+Around every runtime download, the caller runs `pcie_remove` on `$FPGA_HOST`,
+runs `write_bitstream` on `$FPGA_RUNTIME`, and then runs `pcie_rescan` on
+`$FPGA_HOST`. The rescan waits for
 `xdma-chr`, prints the endpoint and device nodes, and verifies access; an
 installed XDMA udev rule avoids a separate `sudo chmod`.
 
@@ -264,26 +276,27 @@ upload_uhd -depth 1000000 -position 0 -clock clk5_p -out uvhs_ila
 
 The FPGA host clears `HOST_IO_ILA_TRIGGER`, invokes `FPGA_ILA_ARM_CMD`, and then
 releases the CPU. It raises that signal at Good Trap or DiffTest failure, then
-invokes `FPGA_ILA_UPLOAD_CMD` during normal host cleanup. Generate both hooks
-with `ila_host_env` so capture starts before CPU release and upload is followed
-by trigger/capture cleanup:
+invokes `FPGA_ILA_UPLOAD_CMD` during normal host cleanup. Generate the host
+environment immediately before `fpga-host` so capture starts before CPU release
+and upload is followed by trigger/capture cleanup:
 
 ```sh
-eval "$(make -s ila_host_env FPGA_BACKEND=uvhs \
-  CPU=<design> SUFFIX=<tag> UVHS_RUNTIME=$UVHS_RUNTIME)"
+eval "$(make -s host_env FPGA_BACKEND=uvhs \
+  CPU=<design> SUFFIX=<tag> FPGA_RUNTIME=<user@fpga-runtime> \
+  WORKLOAD=/path/to/workload.txt)"
+trap 'eval "${FPGA_HOST_CLEANUP_CMD:-:}"' EXIT
 
 /path/to/fpga-host <host arguments>
 ```
 
 The arm command must use the same runtime work directory as
-`uvhs_write_bitstream`. If `$UVHS_HOST` and `$UVHS_RUNTIME` name the same
+`uvhs_write_bitstream`. If `$FPGA_HOST` and `$FPGA_RUNTIME` name the same
 machine, omit the generated SSH wrapper. The trigger signal must be listed in
 the compile-time `trigger_net` group; adding it to RTL with `mark_debug` alone
 is not sufficient.
 
-The generated upload hook clears the trigger after a normal host-triggered
-capture. Clear it explicitly after an interrupted or independently armed
-capture with:
+The generated upload hook clears the trigger after every attempted upload.
+Clear it explicitly after an interrupted or independently armed capture with:
 
 ```sh
 make uvhs_ila_clear CPU=<design> SUFFIX=<tag>
@@ -314,8 +327,7 @@ The upload window is controlled when starting the capture:
 
 ```sh
 make uvhs_ila_arm CPU=<design> SUFFIX=<tag> TRIGGER=/path/to/trigger.ini \
-  UVHS_ILA_POSITION=0 \
-  UVHS_ILA_GATED_CLOCK=<capture-clock-0>,<capture-clock-1>
+  UVHS_ILA_POSITION=0
 make uvhs_ila_upload CPU=<design> SUFFIX=<tag> UVHS_ILA_DEPTH=1000000
 ```
 
@@ -333,12 +345,13 @@ UHD bandwidth, using 512 bits per capture station and clock cycle. The original
 sign-off frequency is restored after upload, after an arm failure, or by
 `uvhs_ila_clear`.
 
-If the compile-time sampling path is gated, pass the exact clock name shown by
-`query -capture` through `UVHS_ILA_GATED_CLOCK`. Use a comma-separated list
-when stations use multiple post-partition clock replicas. The runtime registers
-each clock at the automatically selected capture frequency before installing
-the trigger. This makes the KMH capture stations advance on actual
-`inter_soc_clk` edges, so clock-gated intervals do not consume station samples.
+`UVHS_ILA_GATED_CLOCK` defaults to `fpga_top_debug.core_def.inter_soc_clk` for
+all CPU profiles. Override it with the exact comma-separated names shown by
+`query -capture` when stations use additional post-partition clock replicas.
+The runtime registers each clock at the automatically selected capture
+frequency before installing the trigger. This makes the KMH capture stations
+advance on actual `inter_soc_clk` edges, so clock-gated intervals do not consume
+station samples.
 The vendor documents gated-clock capture as approximate when the clock stops or
 changes frequency; the trigger must also eventually receive a gated-clock edge.
 Use the free-running parent clock for trigger-only profiles that must remain

--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -266,7 +266,8 @@ trigger -ini_check /path/to/trigger.ini
 query -capture
 config -clock -name clk5_p -frequency <bandwidth-limited-frequency>
 config -clock -commit
-trigger -set -gatedclk fpga_top_debug.core_def.inter_soc_clk \
+# ila_arm obtains enabled non-global capture clocks from query -capture.
+trigger -set -gatedclk <clock-from-query-capture> \
   -frequency <bandwidth-limited-frequency> -polarity H
 trigger -set -condition /path/to/trigger.ini -position 0
 capture -enable
@@ -346,13 +347,14 @@ UHD bandwidth, using 512 bits per capture station and clock cycle. The original
 sign-off frequency is restored after upload, after an arm failure, or by
 `uvhs_ila_clear`.
 
-`UVHS_ILA_GATED_CLOCK` defaults to the two replicated gated-clock paths in the
-0804 runtime database. Override it with the exact comma-separated names shown
-by `query -capture` for another bitstream or runtime database.
-The runtime registers each clock at the automatically selected capture
-frequency before installing the trigger. This makes the KMH capture stations
-advance on actual `inter_soc_clk` edges, so clock-gated intervals do not consume
-station samples.
+Before installing the trigger, `ila_arm` queries the enabled UHD capture
+stations. It also queries the global clock names and registers every capture
+station clock that is not a global clock as a gated clock. This removes
+runtime-database-specific clock paths from the Makefile and adapts to replicated
+or otherwise renamed gated clocks in a new bitstream. The runtime registers
+each discovered clock at the automatically selected capture frequency. This
+makes the KMH capture stations advance on actual gated-clock edges, so
+clock-gated intervals do not consume station samples.
 The vendor documents gated-clock capture as approximate when the clock stops or
 changes frequency; the trigger must also eventually receive a gated-clock edge.
 Use the free-running parent clock for trigger-only profiles that must remain

--- a/fpga_diff/uvhs/README.md
+++ b/fpga_diff/uvhs/README.md
@@ -134,7 +134,8 @@ runtime session with `uvhs_write_bitstream` so it reloads and downloads
 
 `host_env` exports ILA arm/upload and DDR fallback settings for `fpga-host`.
 With `BIND_UART=1` (the default), it also creates and exports a run-scoped UART
-bridge; set `BIND_UART=0` to skip it. Upload clears ILA state before returning.
+bridge and rejects an already occupied physical UART; set `BIND_UART=0` to skip
+it. Upload clears ILA state before returning.
 Remote hooks source `REMOTE_ENV`, which defaults to
 `source ~/.bash_profile &&` and can be overridden by the caller.
 Internally, `ila_host_env.sh` generates the ILA/DDR hooks and `bind_uart.sh`
@@ -284,7 +285,7 @@ and upload is followed by trigger/capture cleanup:
 eval "$(make -s host_env FPGA_BACKEND=uvhs \
   CPU=<design> SUFFIX=<tag> FPGA_RUNTIME=<user@fpga-runtime> \
   WORKLOAD=/path/to/workload.txt)"
-trap 'eval "${FPGA_HOST_CLEANUP_CMD:-:}"' EXIT
+trap "${FPGA_HOST_CLEANUP_CMD:-:}" 0
 
 /path/to/fpga-host <host arguments>
 ```
@@ -345,9 +346,9 @@ UHD bandwidth, using 512 bits per capture station and clock cycle. The original
 sign-off frequency is restored after upload, after an arm failure, or by
 `uvhs_ila_clear`.
 
-`UVHS_ILA_GATED_CLOCK` defaults to `fpga_top_debug.core_def.inter_soc_clk` for
-all CPU profiles. Override it with the exact comma-separated names shown by
-`query -capture` when stations use additional post-partition clock replicas.
+`UVHS_ILA_GATED_CLOCK` defaults to the two replicated gated-clock paths in the
+0804 runtime database. Override it with the exact comma-separated names shown
+by `query -capture` for another bitstream or runtime database.
 The runtime registers each clock at the automatically selected capture
 frequency before installing the trigger. This makes the KMH capture stations
 advance on actual `inter_soc_clk` edges, so clock-gated intervals do not consume

--- a/fpga_diff/uvhs/runtime/bind_uart.sh
+++ b/fpga_diff/uvhs/runtime/bind_uart.sh
@@ -17,8 +17,15 @@ command -v socat >/dev/null || {
 
 host_uart="/tmp/fpga-remote-uart-${UID}-$$"
 uart_log="${host_uart}.log"
+remote_uart_check="$remote_env command -v fuser >/dev/null || {"
+remote_uart_check+=" echo 'ERROR: fuser is required on the FPGA runtime' >&2; exit 127; };"
+remote_uart_check+=" if fuser /dev/ttyUSB0 >/dev/null 2>&1; then"
+remote_uart_check+=" echo 'ERROR: /dev/ttyUSB0 already has a reader' >&2;"
+remote_uart_check+=" fuser -v /dev/ttyUSB0 >&2; exit 1; fi"
+env LC_ALL=C ssh -T "$runtime_host" "$remote_uart_check"
+
 remote_uart_command="$remote_env exec socat - /dev/ttyUSB0,rawer,b115200"
-printf -v ssh_command 'ssh -T %q %q' "$runtime_host" "$remote_uart_command"
+printf -v ssh_command 'env LC_ALL=C ssh -T %q %q' "$runtime_host" "$remote_uart_command"
 
 socat -d -d "pty,link=$host_uart,rawer,echo=0,waitslave" \
   "EXEC:$ssh_command,nofork" </dev/null >"$uart_log" 2>&1 &
@@ -33,7 +40,8 @@ trap cleanup_bridge EXIT
 for _ in {1..50}; do
   [[ -L $host_uart ]] && break
   kill -0 "$bridge_pid" 2>/dev/null || {
-    echo "ERROR: failed to start UART bridge; see $uart_log" >&2
+    cat "$uart_log" >&2
+    echo "ERROR: failed to start UART bridge" >&2
     exit 1
   }
   sleep 0.1

--- a/fpga_diff/uvhs/runtime/bind_uart.sh
+++ b/fpga_diff/uvhs/runtime/bind_uart.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+runtime_host=${FPGA_RUNTIME-}
+remote_env=${REMOTE_ENV-}
+
+if [[ -z $runtime_host ]]; then
+  printf 'export FPGA_UART_PORT=%q\n' /dev/ttyUSB0
+  exit 0
+fi
+
+command -v socat >/dev/null || {
+  echo "ERROR: socat is required on the FPGA host" >&2
+  exit 2
+}
+
+host_uart="/tmp/fpga-remote-uart-${UID}-$$"
+uart_log="${host_uart}.log"
+remote_uart_command="$remote_env exec socat - /dev/ttyUSB0,rawer,b115200"
+printf -v ssh_command 'ssh -T %q %q' "$runtime_host" "$remote_uart_command"
+
+socat -d -d "pty,link=$host_uart,rawer,echo=0,waitslave" \
+  "EXEC:$ssh_command,nofork" </dev/null >"$uart_log" 2>&1 &
+bridge_pid=$!
+
+cleanup_bridge() {
+  kill "$bridge_pid" 2>/dev/null || true
+  rm -f -- "$host_uart" "$uart_log"
+}
+trap cleanup_bridge EXIT
+
+for _ in {1..50}; do
+  [[ -L $host_uart ]] && break
+  kill -0 "$bridge_pid" 2>/dev/null || {
+    echo "ERROR: failed to start UART bridge; see $uart_log" >&2
+    exit 1
+  }
+  sleep 0.1
+done
+[[ -L $host_uart ]] || {
+  echo "ERROR: UART PTY was not created; see $uart_log" >&2
+  exit 1
+}
+
+printf -v cleanup_command \
+  'kill %q 2>/dev/null || true; rm -f -- %q %q' \
+  "$bridge_pid" "$host_uart" "$uart_log"
+printf 'export FPGA_UART_PORT=%q\n' "$host_uart"
+printf 'export FPGA_HOST_CLEANUP_CMD=%q\n' "$cleanup_command"
+trap - EXIT

--- a/fpga_diff/uvhs/runtime/ila_host_env.sh
+++ b/fpga_diff/uvhs/runtime/ila_host_env.sh
@@ -11,7 +11,6 @@ workload=${WORKLOAD-}
 trigger=${UVHS_ILA_TRIGGER-}
 position=${UVHS_ILA_POSITION-}
 clock=${UVHS_ILA_CLOCK-}
-gated_clock=${UVHS_ILA_GATED_CLOCK-}
 timeout=${UVHS_ILA_TIMEOUT-}
 depth=${UVHS_ILA_DEPTH-}
 
@@ -44,8 +43,7 @@ make_command() {
 arm_command=$(make_command ila_arm \
   "CPU=$cpu" "SUFFIX=$suffix" \
   "UVHS_ILA_TRIGGER=$trigger" \
-  "UVHS_ILA_POSITION=$position" "UVHS_ILA_CLOCK=$clock" \
-  "UVHS_ILA_GATED_CLOCK=$gated_clock")
+  "UVHS_ILA_POSITION=$position" "UVHS_ILA_CLOCK=$clock")
 upload_command=$(make_command ila_upload \
   "CPU=$cpu" "SUFFIX=$suffix" \
   "UVHS_ILA_TIMEOUT=$timeout" \

--- a/fpga_diff/uvhs/runtime/ila_host_env.sh
+++ b/fpga_diff/uvhs/runtime/ila_host_env.sh
@@ -2,18 +2,18 @@
 
 set -euo pipefail
 
-runtime_host=${1-}
-runtime_dir=${2-}
-runtime_env=${3-}
-cpu=${4-}
-suffix=${5-}
-project_name=${6-}
-trigger=${7-}
-position=${8-}
-clock=${9-}
-gated_clock=${10-}
-timeout=${11-}
-depth=${12-}
+runtime_host=${FPGA_RUNTIME-}
+runtime_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+remote_env=${REMOTE_ENV-}
+cpu=${CPU-}
+suffix=${SUFFIX-}
+workload=${WORKLOAD-}
+trigger=${UVHS_ILA_TRIGGER-}
+position=${UVHS_ILA_POSITION-}
+clock=${UVHS_ILA_CLOCK-}
+gated_clock=${UVHS_ILA_GATED_CLOCK-}
+timeout=${UVHS_ILA_TIMEOUT-}
+depth=${UVHS_ILA_DEPTH-}
 
 [[ -n $cpu ]] || {
   echo "ERROR: CPU is not set" >&2
@@ -35,27 +35,25 @@ make_command() {
   done
 
   if [[ -n $runtime_host ]]; then
-    printf 'ssh %q %q' "$runtime_host" "$runtime_env $command"
+    printf 'ssh %q %q' "$runtime_host" "$remote_env $command"
   else
     printf '%s' "$command"
   fi
 }
 
 arm_command=$(make_command ila_arm \
-  "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name" \
+  "CPU=$cpu" "SUFFIX=$suffix" \
   "UVHS_ILA_TRIGGER=$trigger" \
   "UVHS_ILA_POSITION=$position" "UVHS_ILA_CLOCK=$clock" \
   "UVHS_ILA_GATED_CLOCK=$gated_clock")
 upload_command=$(make_command ila_upload \
-  "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name" \
+  "CPU=$cpu" "SUFFIX=$suffix" \
   "UVHS_ILA_TIMEOUT=$timeout" \
   "UVHS_ILA_DEPTH=$depth" "UVHS_ILA_CLOCK=$clock")
 clear_command=$(make_command ila_clear \
-  "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name")
-runtime_stop_command=$(make_command runtime_stop \
-  "CPU=$cpu" "SUFFIX=$suffix" "PRJ_NAME=$project_name")
+  "CPU=$cpu" "SUFFIX=$suffix")
 
-# Preserve an upload failure while always releasing the capture and restoring
+# Preserve an upload failure while always releasing capture state and restoring
 # any clock temporarily reduced for UHD bandwidth.
 upload_and_clear_command="upload_status=0; $upload_command || upload_status=\$?;"
 upload_and_clear_command+=" clear_status=0; $clear_command || clear_status=\$?;"
@@ -64,5 +62,12 @@ upload_and_clear_command+=" exit \$clear_status"
 
 printf 'export FPGA_ILA_ARM_CMD=%q\n' "$arm_command"
 printf 'export FPGA_ILA_UPLOAD_CMD=%q\n' "$upload_and_clear_command"
-printf 'export FPGA_ILA_CLEAR_CMD=%q\n' "$clear_command"
-printf 'export FPGA_RUNTIME_STOP_CMD=%q\n' "$runtime_stop_command"
+
+if [[ -n $workload ]]; then
+  write_ddr_command=$(make_command write_ddr \
+    "CPU=$cpu" "SUFFIX=$suffix" "WORKLOAD=$workload")
+  reset_cpu_command=$(make_command reset_cpu \
+    "CPU=$cpu" "SUFFIX=$suffix")
+  printf 'export FPGA_DDR_LOAD_CMD=%q\n' \
+    "$write_ddr_command && $reset_cpu_command"
+fi

--- a/fpga_diff/uvhs/runtime/ila_host_env.sh
+++ b/fpga_diff/uvhs/runtime/ila_host_env.sh
@@ -35,7 +35,7 @@ make_command() {
   done
 
   if [[ -n $runtime_host ]]; then
-    printf 'ssh %q %q' "$runtime_host" "$remote_env $command"
+    printf 'env LC_ALL=C ssh %q %q' "$runtime_host" "$remote_env $command"
   else
     printf '%s' "$command"
   fi

--- a/fpga_diff/uvhs/runtime/runtime_server.tcl
+++ b/fpga_diff/uvhs/runtime/runtime_server.tcl
@@ -272,6 +272,77 @@ proc uvhs_query_default_clock_frequency {clock} {
     return [lindex $frequencies 0]
 }
 
+proc uvhs_query_clock_names {} {
+    set names {}
+    foreach line [split [query -clock -tclobj] "\n"] {
+        set fields [regexp -all -inline {\S+} $line]
+        if {[llength $fields] >= 6 &&
+            [string is double -strict [lindex $fields 3]]} {
+            lappend names [lindex $fields 4]
+        }
+    }
+    return [lsort -unique $names]
+}
+
+proc uvhs_query_capture_rows {} {
+    set rows {}
+    set row ""
+    foreach line [split [query -capture -tclobj] "\n"] {
+        set trimmed [string trim $line]
+        if {[regexp -nocase {^B[0-9]+(?:\.[Ff][0-9]+|[[:space:]]+F[0-9]+)[[:space:]]+} $trimmed]} {
+            if {$row ne ""} {
+                lappend rows $row
+            }
+            set row $trimmed
+        } elseif {$row ne "" && $trimmed ne ""} {
+            # UVHS wraps long clock paths at the terminal width. The wrapped
+            # fragment is part of the same field and must be joined verbatim.
+            append row $trimmed
+        }
+    }
+    if {$row ne ""} {
+        lappend rows $row
+    }
+    return $rows
+}
+
+proc uvhs_query_gated_clocks {} {
+    set global_clocks [uvhs_query_clock_names]
+    set gated_clocks {}
+    foreach row [uvhs_query_capture_rows] {
+        set fields [regexp -all -inline {\S+} $row]
+        if {[llength $fields] < 6} {
+            continue
+        }
+
+        set port_index 2
+        set enable_index 3
+        set enabled_values {yes true 1 enable enabled}
+        if {[regexp -nocase {^(B[0-9]+)\.(F[0-9]+)$} \
+                [lindex $fields 0] -> board fpga_id]} {
+            # Current UVHS objects print B0.F2 in the first two columns.
+        } elseif {[regexp -nocase {^B[0-9]+$} [lindex $fields 0]] &&
+                  [regexp -nocase {^F[0-9]+$} [lindex $fields 1]]} {
+            # Older UVHS Tcl objects print B0 and F2 separately.
+            set enabled_values {no false 0}
+        } else {
+            continue
+        }
+
+        if {![string is integer -strict [lindex $fields $port_index]] ||
+            [string tolower [lindex $fields $enable_index]] ni $enabled_values ||
+            ![string is integer -strict [lindex $fields end]]} {
+            continue
+        }
+        set clock [join [lrange $fields 5 end-1] ""]
+        if {$clock eq "" || [lsearch -exact $global_clocks $clock] >= 0} {
+            continue
+        }
+        lappend gated_clocks $clock
+    }
+    return [lsort -unique $gated_clocks]
+}
+
 proc uvhs_configure_tmclk_from_cpu {{cpu_frequency ""}} {
     # Keep the CPU-to-TMCLK relationship stable across sign-off frequencies.
     # The environment variable remains available for controlled experiments,
@@ -302,8 +373,8 @@ proc uvhs_configure_tmclk_from_cpu {{cpu_frequency ""}} {
 
 proc uvhs_capture_station_counts {} {
     set counts {}
-    foreach line [split [query -capture -tclobj] "\n"] {
-        set fields [regexp -all -inline {\S+} $line]
+    foreach row [uvhs_query_capture_rows] {
+        set fields [regexp -all -inline {\S+} $row]
         if {[llength $fields] < 5} {
             continue
         }
@@ -394,9 +465,7 @@ proc uvhs_prepare_ila_clock {clock} {
     return $applied_frequency
 }
 
-proc uvhs_ila_arm {
-    trigger_file position clock gated_clocks
-} {
+proc uvhs_ila_arm {trigger_file position clock} {
     if {![file isfile $trigger_file]} {
         error "trigger condition file not found: $trigger_file"
     }
@@ -414,11 +483,9 @@ proc uvhs_ila_arm {
     trigger -ini_check $trigger_file
     set status [catch {
         set capture_frequency [uvhs_prepare_ila_clock $clock]
-        foreach gated_clock [split $gated_clocks ","] {
-            set gated_clock [string trim $gated_clock]
-            if {$gated_clock eq ""} {
-                continue
-            }
+        set gated_clocks [uvhs_query_gated_clocks]
+        puts "INFO: gated capture clocks from query -capture: $gated_clocks"
+        foreach gated_clock $gated_clocks {
             trigger -set -gatedclk $gated_clock \
                 -frequency $capture_frequency -polarity H
         }
@@ -524,7 +591,7 @@ proc uvhs_execute_command {args} {
             uvhs_release_cpu_after_memory
         }
         ila_arm {
-            if {[llength $args] != 5} { error "ila_arm expects 4 arguments" }
+            if {[llength $args] != 4} { error "ila_arm expects 3 arguments" }
             uvhs_ila_arm {*}[lrange $args 1 4]
         }
         ila_upload {

--- a/fpga_diff/uvhs/uvhs.mk
+++ b/fpga_diff/uvhs/uvhs.mk
@@ -34,9 +34,6 @@ UVHS_ILA_TIMEOUT ?= 60
 UVHS_ILA_DEPTH ?= 1000000
 UVHS_ILA_POSITION ?= 0
 UVHS_ILA_CLOCK ?= clk5_p
-# 0804 hw.dat exposes the replicated CPU gated clocks below; override this for
-# a different runtime database.
-UVHS_ILA_GATED_CLOCK ?= b0/f0/part_0/UV_REPLICATED_CLOCKCONE/SOC_CLK_CTRL_UVin_bufgce_1/O,b0/f2/part_2/core_def/SOC_CLK_CTRL_UVin_bufgce_1/O
 UVHS_ILA_TRIGGER ?= $(UVHS_RUNTIME_DIR)/trigger.ini
 # uv_shell writes UHD output below its project-local runtime work directory.
 UVHS_ILA_OUTPUT_DIR := $(UVHS_RUNTIME_WORK_DIR)/UHD/uvhs_ila
@@ -205,7 +202,7 @@ uvhs_ila_arm:
 	test -f "$(UVHS_ILA_TRIGGER)"
 	$(call uvhs_runtime_command,ila_arm \
 		"$(abspath $(UVHS_ILA_TRIGGER))" "$(UVHS_ILA_POSITION)" \
-		"$(UVHS_ILA_CLOCK)" "$(UVHS_ILA_GATED_CLOCK)")
+		"$(UVHS_ILA_CLOCK)")
 
 uvhs_ila_upload:
 	$(call uvhs_runtime_command,ila_upload uvhs_ila \
@@ -223,7 +220,6 @@ uvhs_host_env:
 		UVHS_ILA_TRIGGER="$(UVHS_ILA_TRIGGER)" \
 		UVHS_ILA_POSITION="$(UVHS_ILA_POSITION)" \
 		UVHS_ILA_CLOCK="$(UVHS_ILA_CLOCK)" \
-		UVHS_ILA_GATED_CLOCK="$(UVHS_ILA_GATED_CLOCK)" \
 		UVHS_ILA_TIMEOUT="$(UVHS_ILA_TIMEOUT)" \
 		UVHS_ILA_DEPTH="$(UVHS_ILA_DEPTH)" \
 		bash "$(UVHS_RUNTIME_DIR)/ila_host_env.sh"

--- a/fpga_diff/uvhs/uvhs.mk
+++ b/fpga_diff/uvhs/uvhs.mk
@@ -34,14 +34,8 @@ UVHS_ILA_TIMEOUT ?= 60
 UVHS_ILA_DEPTH ?= 1000000
 UVHS_ILA_POSITION ?= 0
 UVHS_ILA_CLOCK ?= clk5_p
-UVHS_ILA_GATED_CLOCK ?=
-# Settings used to construct fpga-host hooks.
-UVHS_RUNTIME ?=
-# This must name the fpga_diff checkout visible on UVHS_RUNTIME; it cannot be
-# inferred when the runtime host has multiple checkouts.
-UVHS_ILA_DIR ?= $(UVHS_ROOT_DIR)
-UVHS_ILA_ENV ?= source ~/.bashrc &&
-UVHS_ILA_TRIGGER ?= $(UVHS_ILA_DIR)/uvhs/runtime/trigger.ini
+UVHS_ILA_GATED_CLOCK ?= fpga_top_debug.core_def.inter_soc_clk
+UVHS_ILA_TRIGGER ?= $(UVHS_RUNTIME_DIR)/trigger.ini
 # uv_shell writes UHD output below its project-local runtime work directory.
 UVHS_ILA_OUTPUT_DIR := $(UVHS_RUNTIME_WORK_DIR)/UHD/uvhs_ila
 UVHS_ILA_USDB := $(UVHS_ILA_OUTPUT_DIR)/UvData.usdb
@@ -69,7 +63,7 @@ UVHS_FLOW_ENV = \
 	uvhs_halt_soc uvhs_reset_cpu uvhs_write_ddr uvhs_write_flash \
 	uvhs_ila_arm uvhs_ila_upload uvhs_vcd uvhs_ila_clear \
 	uvhs_runtime_status uvhs_runtime_stop uvhs_bitstream \
-	uvhs_stage_bitstream uvhs_ila_host_env
+	uvhs_stage_bitstream uvhs_host_env
 
 # Validate host tools and external inputs before starting a multi-hour build.
 uvhs_preflight: check_project_name
@@ -191,7 +185,19 @@ uvhs_write_flash:
 	$(call uvhs_runtime_command,write_flash "$(abspath $(WORKLOAD))" 0x0 0x8000)
 
 uvhs_stage_bitstream:
-	@echo "UVHS implementation database: $(UVHS_RUNTIME_DB)"
+	@test -n "$(FPGA_BIT_ARTIFACT_DIR)" && test "$(FPGA_BIT_ARTIFACT_DIR)" != "/" || { \
+		echo "ERROR: please set a safe FPGA_BIT_ARTIFACT_DIR=..." >&2; exit 2; \
+	}
+	@test -d "$(UVHS_RUNTIME_DB)"
+	@mkdir -p "$(FPGA_BIT_ARTIFACT_DIR)/runtime"
+	@test ! -e "$(FPGA_BIT_ARTIFACT_DIR)/runtime/$(PRJ_NAME)" || { \
+		echo "ERROR: runtime artifact already exists; clean the bit archive first" >&2; exit 2; \
+	}
+	@mkdir -p "$(FPGA_BIT_ARTIFACT_DIR)/runtime/$(PRJ_NAME)"
+	@cp -a --reflink=auto "$(UVHS_RUNTIME_DB)" \
+		"$(FPGA_BIT_ARTIFACT_DIR)/runtime/$(PRJ_NAME)/"
+	@echo "FPGA_RUNTIME_ARTIFACT=$(FPGA_BIT_ARTIFACT_DIR)/runtime/$(PRJ_NAME)"
+	@echo "FPGA_RUNTIME_DEST=env-scripts/fpga_diff/$(PRJ_NAME)"
 
 uvhs_ila_arm:
 	test -f "$(UVHS_ILA_TRIGGER)"
@@ -207,14 +213,22 @@ uvhs_ila_upload:
 	$(MAKE) uvhs_vcd
 	@echo "UVHS_ILA_USDB=$(UVHS_ILA_USDB)"
 
-# Print sourceable host/runtime lifecycle commands. They use the public backend
-# targets so callers do not depend on UVHS implementation names.
-uvhs_ila_host_env:
-	@bash "$(UVHS_RUNTIME_DIR)/ila_host_env.sh" \
-		"$(UVHS_RUNTIME)" "$(UVHS_ILA_DIR)" \
-		"$(UVHS_ILA_ENV)" "$(CPU)" "$(SUFFIX)" "$(PRJ_NAME)" \
-		"$(UVHS_ILA_TRIGGER)" "$(UVHS_ILA_POSITION)" "$(UVHS_ILA_CLOCK)" \
-		"$(UVHS_ILA_GATED_CLOCK)" "$(UVHS_ILA_TIMEOUT)" "$(UVHS_ILA_DEPTH)"
+# Print sourceable ILA/DDR hooks, then optionally establish the UART bridge.
+uvhs_host_env:
+	@FPGA_RUNTIME="$(FPGA_RUNTIME)" \
+		REMOTE_ENV="$(REMOTE_ENV)" CPU="$(CPU)" SUFFIX="$(SUFFIX)" \
+		WORKLOAD="$(WORKLOAD)" \
+		UVHS_ILA_TRIGGER="$(UVHS_ILA_TRIGGER)" \
+		UVHS_ILA_POSITION="$(UVHS_ILA_POSITION)" \
+		UVHS_ILA_CLOCK="$(UVHS_ILA_CLOCK)" \
+		UVHS_ILA_GATED_CLOCK="$(UVHS_ILA_GATED_CLOCK)" \
+		UVHS_ILA_TIMEOUT="$(UVHS_ILA_TIMEOUT)" \
+		UVHS_ILA_DEPTH="$(UVHS_ILA_DEPTH)" \
+		bash "$(UVHS_RUNTIME_DIR)/ila_host_env.sh"
+	@if [ "$(BIND_UART)" = 1 ]; then \
+		FPGA_RUNTIME="$(FPGA_RUNTIME)" REMOTE_ENV="$(REMOTE_ENV)" \
+			bash "$(UVHS_RUNTIME_DIR)/bind_uart.sh"; \
+	fi
 
 uvhs_vcd:
 	test -x "$$UV_ROOT/uvd/uvs/bin/usdb2vcd"

--- a/fpga_diff/uvhs/uvhs.mk
+++ b/fpga_diff/uvhs/uvhs.mk
@@ -34,7 +34,9 @@ UVHS_ILA_TIMEOUT ?= 60
 UVHS_ILA_DEPTH ?= 1000000
 UVHS_ILA_POSITION ?= 0
 UVHS_ILA_CLOCK ?= clk5_p
-UVHS_ILA_GATED_CLOCK ?= fpga_top_debug.core_def.inter_soc_clk
+# 0804 hw.dat exposes the replicated CPU gated clocks below; override this for
+# a different runtime database.
+UVHS_ILA_GATED_CLOCK ?= b0/f0/part_0/UV_REPLICATED_CLOCKCONE/SOC_CLK_CTRL_UVin_bufgce_1/O,b0/f2/part_2/core_def/SOC_CLK_CTRL_UVin_bufgce_1/O
 UVHS_ILA_TRIGGER ?= $(UVHS_RUNTIME_DIR)/trigger.ini
 # uv_shell writes UHD output below its project-local runtime work directory.
 UVHS_ILA_OUTPUT_DIR := $(UVHS_RUNTIME_WORK_DIR)/UHD/uvhs_ila

--- a/fpga_diff/vivado/vivado.mk
+++ b/fpga_diff/vivado/vivado.mk
@@ -21,7 +21,7 @@ VIVADO_VERSION := $(shell vivado -version 2>/dev/null | head -1 | grep -o '[0-9]
 	vivado_write_bitstream vivado_halt_soc vivado_write_ddr \
 	vivado_write_flash vivado_reset_cpu vivado_runtime_status \
 	vivado_runtime_stop vivado_ila_arm vivado_ila_upload vivado_ila_clear \
-	vivado_ila_host_env vivado synth check_vivado_version check_version \
+	vivado_host_env vivado synth check_vivado_version check_version \
 	update_core_flist get_impl_log get_synth_log
 
 check_vivado_version:
@@ -89,11 +89,11 @@ vivado_reset_cpu:
 	vivado -mode tcl -source "$(VIVADO_SCRIPT_DIR)/reset_cpu.tcl" \
 		-tclargs $(FPGA_BIT_HOME)/fpga_top_debug.ltx
 
-vivado_runtime_status vivado_runtime_stop vivado_ila_arm:
+vivado_runtime_status vivado_ila_arm:
 	@echo "ERROR: $(@:vivado_%=%) requires FPGA_BACKEND=uvhs" >&2
 	@exit 2
 
-vivado_ila_host_env:
+vivado_runtime_stop vivado_host_env:
 	@:
 
 vivado_ila_upload:


### PR DESCRIPTION
## Summary

- Expose local `pcie_remove` and `pcie_rescan` targets for caller-owned split-host orchestration.
- Provide a backend-neutral `host_env` entry point: Vivado emits no extra settings, while UVHS supplies ILA arm/upload hooks and the DDR fallback hook.
- Keep ILA/DDR generation in `ila_host_env.sh`; with `BIND_UART=1` by default, additionally call `bind_uart.sh` to bridge runtime `/dev/ttyUSB0` to a unique host PTY and export its cleanup command.
- Use `fpga_top_debug.core_def.inter_soc_clk` as the default gated ILA clock for every CPU profile.
- Keep ILA clear inside every upload attempt instead of runtime cleanup.
- Make backend-neutral `runtime_stop` release UVHS and do nothing for Vivado.
- Derive `PRJ_NAME` from backend, CPU, and suffix, and stage a portable UVHS runtime database with copyable paths.
- Validate the rebound XDMA driver, device nodes, permissions, and live PCI configuration after rescan.

## Responsibility

env-scripts provides local programming, XDMA, `host_env`, UART, ILA, DDR, and runtime-control capabilities. Machine selection, SSH ordering, artifact deployment, and process lifecycle remain caller responsibilities.

The corresponding Minjie orchestration is tracked by OpenXiangShan/minjie-playground#31.

## Validation

- Rebased onto current `main@d93f67e`.
- `make -C fpga_diff -pn check_project_name CPU=kmh`
- `bash -n fpga_diff/uvhs/runtime/ila_host_env.sh fpga_diff/uvhs/runtime/bind_uart.sh fpga_diff/tools/pcie-remove.sh fpga_diff/tools/pcie-rescan.sh`
- `git diff --check origin/main...HEAD`
- Verified `BIND_UART=0` runs only `ila_host_env.sh` and emits no UART or cleanup exports.
- Verified the default `BIND_UART=1` combines ILA hooks with the local UART path when runtime and host are the same machine.
- Verified `kmh`, `nutshell`, and `nanhu` expand the same default `UVHS_ILA_GATED_CLOCK`.
- Verified the generated ILA upload command orders `ila_upload` before `ila_clear`.
- Verified Vivado `runtime_stop` succeeds as an empty backend implementation.
- Retained the staged runtime artifact, custom `REMOTE_ENV`, and XDMA rescan checks from the earlier revision.

The final commit was not used for a new full board run.